### PR TITLE
Ensure status indicator resets error state before evaluating connection

### DIFF
--- a/conseiller-rgpd.js
+++ b/conseiller-rgpd.js
@@ -298,8 +298,9 @@ Comment puis-je vous accompagner dans votre démarche de conformité RGPD aujour
         
         if (!statusDot || !statusText) return;
 
+        statusDot.classList.remove('error');
+
         if (connected === true) {
-            statusDot.classList.remove('error');
             statusText.textContent = text || 'Connecté';
         } else if (connected === false) {
             statusDot.classList.add('error');


### PR DESCRIPTION
## Summary
- Always remove previous `error` class from the status indicator before checking connection state

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a64ec64888832c8b41db9ca542a4df