### PR TITLE
refactor: improve typing UX and remove background animation

### DIFF
--- a/conseiller-rgpd.css
+++ b/conseiller-rgpd.css
@@ -34,7 +34,7 @@
 
 body {
     font-family: var(--font-sans);
-    background: linear-gradient(135deg, var(--bg-dark) 0%, var(--bg-dark-secondary) 50%, var(--border) 100%);
+    background: var(--bg-dark);
     min-height: 100vh;
     display: flex;
     justify-content: center;
@@ -46,7 +46,6 @@ body {
     line-height: 1.6;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    transition: background 0.3s ease;
 }
 
 
@@ -528,6 +527,12 @@ body {
     cursor: not-allowed;
 }
 
+/* Effet de frappe dans le champ de saisie */
+.message-input.typing {
+    border-color: var(--primary-light);
+    box-shadow: 0 0 0 4px rgba(20, 184, 166, 0.15);
+}
+
 .send-button {
     padding: 16px 32px;
     background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
@@ -543,6 +548,12 @@ body {
     gap: 8px;
     box-shadow: 0 4px 12px rgba(15, 118, 110, 0.3);
     letter-spacing: 0.5px;
+}
+
+.send-button.active {
+    transform: translateY(-2px);
+    background: linear-gradient(135deg, var(--primary-light) 0%, var(--secondary) 100%);
+    box-shadow: 0 8px 20px rgba(15, 118, 110, 0.4);
 }
 
 .send-button:hover:not(:disabled) {

--- a/conseiller-rgpd.js
+++ b/conseiller-rgpd.js
@@ -28,7 +28,8 @@ class ConseillerRGPDApp {
         this.updateDateTime();
         this.showWelcomeMessage();
         this.focusInput();
-        
+        this.updateSendButtonState();
+
         // Mise à jour de l'heure chaque seconde
         setInterval(() => this.updateDateTime(), 1000);
     }
@@ -46,6 +47,19 @@ class ConseillerRGPDApp {
         const chatForm = document.getElementById('chatForm');
         if (chatForm) {
             chatForm.addEventListener('submit', (e) => this.handleFormSubmit(e));
+        }
+
+        // Effets visuels pendant la frappe
+        if (this.messageInput) {
+            let inputRaf;
+            this.messageInput.addEventListener('input', () => {
+                cancelAnimationFrame(inputRaf);
+                inputRaf = requestAnimationFrame(() => {
+                    const hasText = this.messageInput.value.trim().length > 0;
+                    this.messageInput.classList.toggle('typing', hasText);
+                    this.updateSendButtonState();
+                });
+            });
         }
 
         // Raccourcis clavier
@@ -79,9 +93,9 @@ class ConseillerRGPDApp {
 
     async handleFormSubmit(e) {
         e.preventDefault();
-        
+
         if (this.isProcessing) return;
-        
+
         const messageInput = this.messageInput;
         const message = messageInput.value.trim();
         
@@ -96,6 +110,7 @@ class ConseillerRGPDApp {
         }
 
         messageInput.value = '';
+        this.updateSendButtonState();
         await this.sendMessage(message);
     }
 
@@ -162,8 +177,16 @@ class ConseillerRGPDApp {
                 sendButton.classList.remove('loading');
             }
         }
-        
+
         this.updateStatus(processing ? null : true, processing ? 'Traitement...' : 'Connecté');
+        this.updateSendButtonState();
+    }
+
+    updateSendButtonState() {
+        const sendButton = this.sendButton;
+        if (!sendButton) return;
+        const hasText = this.messageInput && this.messageInput.value.trim().length > 0;
+        sendButton.classList.toggle('active', hasText && !this.isProcessing && !sendButton.disabled);
     }
 
     addMessage(content, isUser = false, isError = false) {


### PR DESCRIPTION
## Summary
- Remove animated gradient for a static dark background
- Highlight input and send button while typing with new CSS classes
- Throttle input handling and update send button state for faster perceived UI

## Testing
- `php -l conseiller-rgpd.php`
- `node --check conseiller-rgpd.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8668bde44832ca9662d51e701060c