### PR TITLE
Add service worker with environment-aware registration

### DIFF
--- a/conseiller-rgpd.js
+++ b/conseiller-rgpd.js
@@ -1,3 +1,4 @@
+
 /**
  * Conseiller RGPD IA - Application JavaScript
  * Powered by Symplissime AI
@@ -524,3 +525,22 @@ window.rgpdApp = {
     exportHistory: () => rgpdApp?.exportChatHistory(),
     clearHistory: () => rgpdApp?.clearHistory()
 };
+
+// Service Worker registration with development safeguard
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        const isLocalhost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+
+        if (isLocalhost) {
+            console.log('Service Worker disabled for development environment');
+        } else {
+            navigator.serviceWorker.register('sw.js')
+                .then(() => {
+                    console.log('Service Worker registered successfully');
+                })
+                .catch(error => {
+                    console.error('SW registration failed:', error);
+                });
+        }
+    });
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,13 @@
+self.addEventListener('install', event => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});
+
+// Placeholder fetch handler
+self.addEventListener('fetch', () => {
+  // Intentionally empty - can be expanded for offline caching
+});
+


### PR DESCRIPTION
## Summary
- register service worker only in production environments and log when disabled for localhost
- add placeholder `sw.js` to avoid 404 and enable future offline features

## Testing
- `php -l conseiller-rgpd.php`
- `node --check conseiller-rgpd.js && echo "conseiller-rgpd.js OK"`
- `node --check sw.js && echo "sw.js OK"`


------
https://chatgpt.com/codex/tasks/task_e_68a8849fecc4832ca7c61808e46e7ecd