### PR TITLE
feat: add Markdown rendering and code highlighting

### DIFF
--- a/conseiller-rgpd.js
+++ b/conseiller-rgpd.js
@@ -231,7 +231,14 @@ class ConseillerRGPDApp {
         // Sécurisation et rendu du contenu
         if (!isUser && !isError) {
             const html = DOMPurify.sanitize(marked.parse(content));
-            message.innerHTML = html;
+            let html;
+            try {
+                html = DOMPurify.sanitize(marked.parse(content));
+                message.innerHTML = html;
+            } catch (e) {
+                // Fallback: render as plain text if Markdown parsing fails
+                message.textContent = content;
+            }
         } else {
             message.textContent = content;
         }

--- a/conseiller-rgpd.js
+++ b/conseiller-rgpd.js
@@ -5,6 +5,13 @@
  * Version 3.1
  */
 
+// Configuration de Marked pour la coloration syntaxique
+if (typeof marked !== 'undefined') {
+    marked.setOptions({
+        highlight: (code, lang) => hljs.highlightAuto(code).value
+    });
+}
+
 class ConseillerRGPDApp {
     constructor() {
         this.config = window.RGPD_CONFIG || {};
@@ -215,9 +222,14 @@ class ConseillerRGPDApp {
         
         const message = document.createElement('div');
         message.className = `message ${isUser ? 'user' : 'bot'} ${isError ? 'error' : ''}`;
-        
-        // Sécurisation du contenu
-        message.textContent = content;
+
+        // Sécurisation et rendu du contenu
+        if (!isUser && !isError) {
+            const html = DOMPurify.sanitize(marked.parse(content));
+            message.innerHTML = html;
+        } else {
+            message.textContent = content;
+        }
         
         messageContent.appendChild(message);
         
@@ -230,11 +242,35 @@ class ConseillerRGPDApp {
         wrapper.appendChild(avatar);
         wrapper.appendChild(messageContent);
         chatMessages.appendChild(wrapper);
+
+        // Coloration syntaxique pour les messages du bot
+        if (!isUser && !isError) {
+            wrapper.querySelectorAll('pre code').forEach(block => {
+                hljs.highlightElement(block);
+            });
+        }
         
         // Enregistrer dans l'historique
         this.messageHistory.push({ content, isUser, isError, timestamp: new Date() });
         
         this.scrollToBottom();
+    }
+
+    streamMessage(messageElement, text) {
+        if (messageElement) {
+            messageElement.textContent += text;
+        }
+    }
+
+    finishStreaming(messageElement) {
+        if (messageElement) {
+            const fullText = messageElement.textContent;
+            const html = DOMPurify.sanitize(marked.parse(fullText));
+            messageElement.innerHTML = html;
+            messageElement.querySelectorAll('pre code').forEach(block => {
+                hljs.highlightElement(block);
+            });
+        }
     }
 
     createMessageActions(content) {

--- a/conseiller-rgpd.js
+++ b/conseiller-rgpd.js
@@ -277,7 +277,14 @@ class ConseillerRGPDApp {
     finishStreaming(messageElement) {
         if (messageElement) {
             const fullText = messageElement.textContent;
-            const html = DOMPurify.sanitize(marked.parse(fullText));
+            let html;
+            try {
+                html = DOMPurify.sanitize(marked.parse(fullText));
+            } catch (e) {
+                html = DOMPurify.sanitize('<div class="error-message">Erreur lors de l\'affichage du message.</div>');
+                // Optionally, log the error for debugging:
+                // console.error('Markdown parsing error:', e);
+            }
             messageElement.innerHTML = html;
             messageElement.querySelectorAll('pre code').forEach(block => {
                 hljs.highlightElement(block);

--- a/conseiller-rgpd.js
+++ b/conseiller-rgpd.js
@@ -8,7 +8,12 @@
 // Configuration de Marked pour la coloration syntaxique
 if (typeof marked !== 'undefined') {
     marked.setOptions({
-        highlight: (code, lang) => hljs.highlightAuto(code).value
+        highlight: (code, lang) => {
+            if (lang && hljs.getLanguage(lang)) {
+                return hljs.highlight(code, {language: lang}).value;
+            }
+            return hljs.highlightAuto(code).value;
+        }
     });
 }
 

--- a/conseiller-rgpd.php
+++ b/conseiller-rgpd.php
@@ -96,6 +96,7 @@ if (isset($_POST['action']) && $_POST['action'] === 'chat') {
     <title>Conseiller RGPD IA v<?php echo htmlspecialchars($APP_VERSION); ?> - Powered by Symplissime AI</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="conseiller-rgpd.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
 </head>
 <body>
     <!-- Symplissime Branding -->
@@ -170,7 +171,9 @@ if (isset($_POST['action']) && $_POST['action'] === 'chat') {
             VERSION: '<?php echo $APP_VERSION; ?>'
         };
     </script>
-    
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
     <script src="conseiller-rgpd.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- render bot messages as sanitized Markdown using Marked, DOMPurify, and highlight.js
- add streaming helpers for progressive updates
- load required CDN scripts and highlight theme

## Testing
- `php -l conseiller-rgpd.php`
- `node --check conseiller-rgpd.js && echo "syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68a8a5df8bec832c80b9396d8bed89f4