### PR TITLE
feat: improve message rendering with typogr

### DIFF
--- a/conseiller-rgpd.js
+++ b/conseiller-rgpd.js
@@ -232,7 +232,9 @@ class ConseillerRGPDApp {
         if (!isUser && !isError) {
             let html;
             try {
-                html = DOMPurify.sanitize(marked.parse(content));
+                html = marked.parse(content);
+                html = DOMPurify.sanitize(html);
+                html = typogr.typogrify(html);
                 message.innerHTML = html;
             } catch (e) {
                 // Fallback: render as plain text if Markdown parsing fails
@@ -278,7 +280,9 @@ class ConseillerRGPDApp {
             const fullText = messageElement.textContent;
             let html;
             try {
-                html = DOMPurify.sanitize(marked.parse(fullText));
+                html = marked.parse(fullText);
+                html = DOMPurify.sanitize(html);
+                html = typogr.typogrify(html);
             } catch (e) {
                 html = DOMPurify.sanitize('<div class="error-message">Erreur lors de l\'affichage du message.</div>');
                 // Optionally, log the error for debugging:

--- a/conseiller-rgpd.php
+++ b/conseiller-rgpd.php
@@ -171,9 +171,10 @@ if (isset($_POST['action']) && $_POST['action'] === 'chat') {
             VERSION: '<?php echo $APP_VERSION; ?>'
         };
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
-    <script src="conseiller-rgpd.js"></script>
-</body>
+      <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/typogr@0.6.7/typogr.min.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+      <script src="conseiller-rgpd.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- Sanitize and typographically enhance bot messages using Marked, DOMPurify and Typogr
- Ensure final streamed content passes through Marked -> DOMPurify -> Typogr
- Load Typogr from CDN alongside existing libraries

## Testing
- `php -l conseiller-rgpd.php`
- `node --check conseiller-rgpd.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68a8ab842c28832c87a870a65903c647