### PR TITLE
Enhance chat theming and response streaming

### DIFF
--- a/conseiller-rgpd.css
+++ b/conseiller-rgpd.css
@@ -48,6 +48,13 @@ body.theme-ocean {
     --primary-dark: #0369a1;
     --primary-light: #38bdf8;
     --secondary: #0ea5e9;
+    --bg-dark: linear-gradient(135deg, #0f172a 0%, #0e7490 100%);
+    --bg-dark-secondary: #0f172a;
+    --text-primary: #e0f2fe;
+    --text-secondary: #a5f3fc;
+    --border: #164e63;
+    --glass: rgba(2, 132, 199, 0.15);
+    --glass-border: rgba(2, 132, 199, 0.3);
 }
 
 body.theme-forest {
@@ -55,6 +62,13 @@ body.theme-forest {
     --primary-dark: #166534;
     --primary-light: #4ade80;
     --secondary: #065f46;
+    --bg-dark: linear-gradient(135deg, #052e16 0%, #14532d 100%);
+    --bg-dark-secondary: #052e16;
+    --text-primary: #dcfce7;
+    --text-secondary: #a7f3d0;
+    --border: #064e3b;
+    --glass: rgba(22, 163, 74, 0.15);
+    --glass-border: rgba(22, 163, 74, 0.3);
 }
 
 body.theme-sunset {
@@ -62,6 +76,13 @@ body.theme-sunset {
     --primary-dark: #9f1239;
     --primary-light: #f472b6;
     --secondary: #c2410c;
+    --bg-dark: linear-gradient(135deg, #4c0519 0%, #9f1239 100%);
+    --bg-dark-secondary: #4c0519;
+    --text-primary: #fee2e2;
+    --text-secondary: #fecdd3;
+    --border: #7f1d1d;
+    --glass: rgba(190, 18, 60, 0.15);
+    --glass-border: rgba(190, 18, 60, 0.3);
 }
 
 body {
@@ -78,6 +99,7 @@ body {
     line-height: 1.6;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    transition: background 0.5s ease, color 0.5s ease;
 }
 
 
@@ -163,7 +185,40 @@ body {
 
 .control-btn:hover {
     transform: scale(1.1);
-    background: rgba(15, 118, 110, 0.2);
+    background: var(--primary-dark);
+    color: var(--text-primary);
+}
+
+.theme-menu {
+    position: absolute;
+    top: 60px;
+    right: 0;
+    display: flex;
+    flex-direction: column;
+    background: var(--glass);
+    backdrop-filter: blur(15px);
+    border: 1px solid var(--glass-border);
+    border-radius: 12px;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4);
+    overflow: hidden;
+    animation: fadeIn 0.2s ease;
+}
+
+.theme-option {
+    padding: 10px 20px;
+    cursor: pointer;
+    color: var(--text-primary);
+    white-space: nowrap;
+    transition: background 0.3s;
+}
+
+.theme-option:hover {
+    background: var(--primary-dark);
+    color: var(--text-primary);
+}
+
+.hidden {
+    display: none;
 }
 
 .main-container {
@@ -736,4 +791,9 @@ body {
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(-10px); }
+    to { opacity: 1; transform: translateY(0); }
 }

--- a/conseiller-rgpd.js
+++ b/conseiller-rgpd.js
@@ -24,7 +24,6 @@ class ConseillerRGPDApp {
         this.isProcessing = false;
         this.messageHistory = [];
         this.colorThemes = ['', 'theme-ocean', 'theme-forest', 'theme-sunset'];
-        this.currentColorThemeIndex = 0;
         // Cache frequently accessed DOM elements
         this.messageInput = document.getElementById('messageInput');
         this.sendButton = document.getElementById('sendButton');
@@ -33,6 +32,7 @@ class ConseillerRGPDApp {
         this.statusText = document.getElementById('statusText');
         this.toast = document.getElementById('toast');
         this.datetimeElement = document.getElementById('datetime');
+        this.themeMenu = document.getElementById('themeMenu');
         
         this.init();
     }
@@ -68,7 +68,6 @@ class ConseillerRGPDApp {
         const savedColorTheme = localStorage.getItem('rgpd_colorTheme');
         if (savedColorTheme && this.colorThemes.includes(savedColorTheme)) {
             document.body.classList.add(savedColorTheme);
-            this.currentColorThemeIndex = this.colorThemes.indexOf(savedColorTheme);
         }
     }
 
@@ -89,6 +88,23 @@ class ConseillerRGPDApp {
                     this.messageInput.classList.toggle('typing', hasText);
                     this.updateSendButtonState();
                 });
+            });
+        }
+
+        if (this.themeMenu) {
+            this.themeMenu.addEventListener('click', (e) => {
+                const theme = e.target.getAttribute('data-theme');
+                if (theme !== null) {
+                    this.applyColorTheme(theme);
+                    this.hideThemeMenu();
+                }
+            });
+
+            document.addEventListener('click', (e) => {
+                const toggle = document.getElementById('colorThemeToggle');
+                if (toggle && !this.themeMenu.contains(e.target) && e.target !== toggle) {
+                    this.hideThemeMenu();
+                }
             });
         }
 
@@ -546,10 +562,20 @@ Comment puis-je vous accompagner dans votre démarche de conformité RGPD aujour
         this.showToast(isLight ? 'Thème clair activé' : 'Thème sombre activé', 'success');
     }
 
-    cycleColorTheme() {
+    toggleThemeMenu() {
+        if (this.themeMenu) {
+            this.themeMenu.classList.toggle('hidden');
+        }
+    }
+
+    hideThemeMenu() {
+        if (this.themeMenu) {
+            this.themeMenu.classList.add('hidden');
+        }
+    }
+
+    applyColorTheme(theme) {
         document.body.classList.remove('theme-ocean', 'theme-forest', 'theme-sunset');
-        this.currentColorThemeIndex = (this.currentColorThemeIndex + 1) % this.colorThemes.length;
-        const theme = this.colorThemes[this.currentColorThemeIndex];
         if (theme) {
             document.body.classList.add(theme);
         }
@@ -611,7 +637,7 @@ window.rgpdApp = {
     increaseFontSize: () => rgpdApp?.increaseFontSize(),
     decreaseFontSize: () => rgpdApp?.decreaseFontSize(),
     toggleTheme: () => rgpdApp?.toggleTheme(),
-    cycleColorTheme: () => rgpdApp?.cycleColorTheme(),
+    toggleThemeMenu: () => rgpdApp?.toggleThemeMenu(),
     exportHistory: () => rgpdApp?.exportChatHistory(),
     clearHistory: () => rgpdApp?.clearHistory()
 };

--- a/conseiller-rgpd.php
+++ b/conseiller-rgpd.php
@@ -84,12 +84,9 @@ if (isset($_POST['action']) && $_POST['action'] === 'chat') {
         $length = mb_strlen($assistantMessage, 'UTF-8');
         for ($i = 0; $i < $length; $i++) {
             echo mb_substr($assistantMessage, $i, 1, 'UTF-8');
-            if ($i % 20 === 0) {
-                echo "\n";
-            }
             @ob_flush();
             flush();
-            usleep(10000);
+            usleep(1000);
         }
     } else {
         http_response_code(500);
@@ -122,7 +119,13 @@ if (isset($_POST['action']) && $_POST['action'] === 'chat') {
         <button class="control-btn" onclick="rgpdApp.decreaseFontSize()" title="Réduire le texte">A-</button>
         <button class="control-btn" onclick="rgpdApp.increaseFontSize()" title="Agrandir le texte">A+</button>
         <button class="control-btn" onclick="rgpdApp.toggleTheme()" title="Basculer le thème" id="themeToggle">🌙</button>
-        <button class="control-btn" onclick="rgpdApp.cycleColorTheme()" title="Changer le thème de couleur" id="colorThemeToggle">🎨</button>
+        <button class="control-btn" onclick="rgpdApp.toggleThemeMenu()" title="Changer le thème de couleur" id="colorThemeToggle">🎨</button>
+        <div class="theme-menu hidden" id="themeMenu">
+            <div class="theme-option" data-theme="">Défaut</div>
+            <div class="theme-option" data-theme="theme-ocean">Océan</div>
+            <div class="theme-option" data-theme="theme-forest">Forêt</div>
+            <div class="theme-option" data-theme="theme-sunset">Crépuscule</div>
+        </div>
     </div>
     
     <div class="main-container">


### PR DESCRIPTION
## Summary
- Add theme selection menu with multiple color schemes and gradients
- Apply theme colors across chat interface with modern effects
- Speed up and clean response streaming to fix column breaks

## Testing
- `php -l conseiller-rgpd.php`
- `node --check conseiller-rgpd.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8b22054dc832ca0c753ffd3c83b63