### PR TITLE
Add modern themes and font selector

### DIFF
--- a/conseiller-rgpd.css
+++ b/conseiller-rgpd.css
@@ -85,6 +85,82 @@ body.theme-sunset {
     --glass-border: rgba(190, 18, 60, 0.3);
 }
 
+body.theme-glass {
+    --primary: rgba(255, 255, 255, 0.8);
+    --primary-dark: rgba(255, 255, 255, 0.6);
+    --primary-light: #ffffff;
+    --secondary: rgba(255, 255, 255, 0.3);
+    --bg-dark: linear-gradient(135deg, rgba(255,255,255,0.2) 0%, rgba(255,255,255,0.05) 100%);
+    --bg-dark-secondary: rgba(255,255,255,0.1);
+    --text-primary: #ffffff;
+    --text-secondary: #e2e8f0;
+    --border: rgba(255,255,255,0.2);
+    --glass: rgba(255,255,255,0.2);
+    --glass-border: rgba(255,255,255,0.3);
+}
+
+body.theme-plasma {
+    --primary: #9333ea;
+    --primary-dark: #7e22ce;
+    --primary-light: #d946ef;
+    --secondary: #06b6d4;
+    --bg-dark: linear-gradient(135deg, #0f172a 0%, #9333ea 50%, #db2777 100%);
+    --bg-dark-secondary: #1e1b4b;
+    --text-primary: #f3e8ff;
+    --text-secondary: #e9d5ff;
+    --border: #6b21a8;
+    --glass: rgba(147, 51, 234, 0.15);
+    --glass-border: rgba(147, 51, 234, 0.3);
+}
+
+body.theme-genmoji {
+    --primary: #f59e0b;
+    --primary-dark: #d97706;
+    --primary-light: #fde68a;
+    --secondary: #10b981;
+    --bg-dark: linear-gradient(135deg, #0f172a 0%, #f59e0b 25%, #10b981 50%, #3b82f6 75%, #db2777 100%);
+    --bg-dark-secondary: #0f172a;
+    --text-primary: #fef3c7;
+    --text-secondary: #fde68a;
+    --border: #92400e;
+    --glass: rgba(245, 158, 11, 0.15);
+    --glass-border: rgba(245, 158, 11, 0.3);
+}
+
+body.theme-neon {
+    --primary: #2dd4bf;
+    --primary-dark: #0d9488;
+    --primary-light: #5eead4;
+    --secondary: #f472b6;
+    --bg-dark: linear-gradient(135deg, #18181b 0%, #0d9488 50%, #f472b6 100%);
+    --bg-dark-secondary: #18181b;
+    --text-primary: #ccfbf1;
+    --text-secondary: #99f6e4;
+    --border: #0f766e;
+    --glass: rgba(20, 184, 166, 0.15);
+    --glass-border: rgba(20, 184, 166, 0.3);
+}
+
+body.theme-holo {
+    --primary: #6366f1;
+    --primary-dark: #4f46e5;
+    --primary-light: #a5b4fc;
+    --secondary: #ec4899;
+    --bg-dark: linear-gradient(135deg, #0f172a 0%, #4f46e5 50%, #ec4899 100%);
+    --bg-dark-secondary: #1e1b4b;
+    --text-primary: #ede9fe;
+    --text-secondary: #ddd6fe;
+    --border: #4338ca;
+    --glass: rgba(99, 102, 241, 0.15);
+    --glass-border: rgba(99, 102, 241, 0.3);
+}
+
+body.font-inter { --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+body.font-roboto { --font-sans: 'Roboto', sans-serif; }
+body.font-lato { --font-sans: 'Lato', sans-serif; }
+body.font-poppins { --font-sans: 'Poppins', sans-serif; }
+body.font-jetbrains { --font-sans: 'JetBrains Mono', monospace; }
+
 body {
     font-family: var(--font-sans);
     background: var(--bg-dark);

--- a/conseiller-rgpd.js
+++ b/conseiller-rgpd.js
@@ -23,7 +23,8 @@ class ConseillerRGPDApp {
         this.fontScale = 1;
         this.isProcessing = false;
         this.messageHistory = [];
-        this.colorThemes = ['', 'theme-ocean', 'theme-forest', 'theme-sunset'];
+        this.colorThemes = ['', 'theme-ocean', 'theme-forest', 'theme-sunset', 'theme-glass', 'theme-plasma', 'theme-genmoji', 'theme-neon', 'theme-holo'];
+        this.fontClasses = ['font-inter', 'font-roboto', 'font-lato', 'font-poppins', 'font-jetbrains'];
         // Cache frequently accessed DOM elements
         this.messageInput = document.getElementById('messageInput');
         this.sendButton = document.getElementById('sendButton');
@@ -33,6 +34,7 @@ class ConseillerRGPDApp {
         this.toast = document.getElementById('toast');
         this.datetimeElement = document.getElementById('datetime');
         this.themeMenu = document.getElementById('themeMenu');
+        this.fontMenu = document.getElementById('fontMenu');
         
         this.init();
     }
@@ -69,6 +71,11 @@ class ConseillerRGPDApp {
         if (savedColorTheme && this.colorThemes.includes(savedColorTheme)) {
             document.body.classList.add(savedColorTheme);
         }
+
+        const savedFont = localStorage.getItem('rgpd_font');
+        if (savedFont && this.fontClasses.includes(savedFont)) {
+            document.body.classList.add(savedFont);
+        }
     }
 
     bindEvents() {
@@ -104,6 +111,23 @@ class ConseillerRGPDApp {
                 const toggle = document.getElementById('colorThemeToggle');
                 if (toggle && !this.themeMenu.contains(e.target) && e.target !== toggle) {
                     this.hideThemeMenu();
+                }
+            });
+        }
+
+        if (this.fontMenu) {
+            this.fontMenu.addEventListener('click', (e) => {
+                const font = e.target.getAttribute('data-font');
+                if (font !== null) {
+                    this.applyFont(font);
+                    this.hideFontMenu();
+                }
+            });
+
+            document.addEventListener('click', (e) => {
+                const toggle = document.getElementById('fontToggle');
+                if (toggle && !this.fontMenu.contains(e.target) && e.target !== toggle) {
+                    this.hideFontMenu();
                 }
             });
         }
@@ -574,8 +598,37 @@ Comment puis-je vous accompagner dans votre démarche de conformité RGPD aujour
         }
     }
 
+    toggleFontMenu() {
+        if (this.fontMenu) {
+            this.fontMenu.classList.toggle('hidden');
+        }
+    }
+
+    hideFontMenu() {
+        if (this.fontMenu) {
+            this.fontMenu.classList.add('hidden');
+        }
+    }
+
+    applyFont(font) {
+        document.body.classList.remove(...this.fontClasses);
+        if (font) {
+            document.body.classList.add(font);
+        }
+        localStorage.setItem('rgpd_font', font);
+        const fontMap = {
+            'font-inter': 'Inter',
+            'font-roboto': 'Roboto',
+            'font-lato': 'Lato',
+            'font-poppins': 'Poppins',
+            'font-jetbrains': 'JetBrains Mono'
+        };
+        const fontName = fontMap[font] || 'défaut';
+        this.showToast(`Police ${fontName} activée`, 'success');
+    }
+
     applyColorTheme(theme) {
-        document.body.classList.remove('theme-ocean', 'theme-forest', 'theme-sunset');
+        document.body.classList.remove(...this.colorThemes.filter(t => t));
         if (theme) {
             document.body.classList.add(theme);
         }
@@ -638,6 +691,7 @@ window.rgpdApp = {
     decreaseFontSize: () => rgpdApp?.decreaseFontSize(),
     toggleTheme: () => rgpdApp?.toggleTheme(),
     toggleThemeMenu: () => rgpdApp?.toggleThemeMenu(),
+    toggleFontMenu: () => rgpdApp?.toggleFontMenu(),
     exportHistory: () => rgpdApp?.exportChatHistory(),
     clearHistory: () => rgpdApp?.clearHistory()
 };

--- a/conseiller-rgpd.php
+++ b/conseiller-rgpd.php
@@ -103,7 +103,7 @@ if (isset($_POST['action']) && $_POST['action'] === 'chat') {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Conseiller RGPD IA v<?php echo htmlspecialchars($APP_VERSION); ?> - Powered by Symplissime AI</title>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&family=Roboto:wght@300;400;500;700&family=Lato:wght@300;400;700&family=Poppins:wght@300;400;500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="conseiller-rgpd.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
 </head>
@@ -120,11 +120,24 @@ if (isset($_POST['action']) && $_POST['action'] === 'chat') {
         <button class="control-btn" onclick="rgpdApp.increaseFontSize()" title="Agrandir le texte">A+</button>
         <button class="control-btn" onclick="rgpdApp.toggleTheme()" title="Basculer le thème" id="themeToggle">🌙</button>
         <button class="control-btn" onclick="rgpdApp.toggleThemeMenu()" title="Changer le thème de couleur" id="colorThemeToggle">🎨</button>
+        <button class="control-btn" onclick="rgpdApp.toggleFontMenu()" title="Changer la police" id="fontToggle">🅰️</button>
         <div class="theme-menu hidden" id="themeMenu">
             <div class="theme-option" data-theme="">Défaut</div>
             <div class="theme-option" data-theme="theme-ocean">Océan</div>
             <div class="theme-option" data-theme="theme-forest">Forêt</div>
             <div class="theme-option" data-theme="theme-sunset">Crépuscule</div>
+            <div class="theme-option" data-theme="theme-glass">Glass</div>
+            <div class="theme-option" data-theme="theme-plasma">Plasma</div>
+            <div class="theme-option" data-theme="theme-genmoji">Genmoji</div>
+            <div class="theme-option" data-theme="theme-neon">Néon</div>
+            <div class="theme-option" data-theme="theme-holo">Holo</div>
+        </div>
+        <div class="theme-menu hidden" id="fontMenu">
+            <div class="theme-option" data-font="font-inter">Inter</div>
+            <div class="theme-option" data-font="font-roboto">Roboto</div>
+            <div class="theme-option" data-font="font-lato">Lato</div>
+            <div class="theme-option" data-font="font-poppins">Poppins</div>
+            <div class="theme-option" data-font="font-jetbrains">JetBrains Mono</div>
         </div>
     </div>
     


### PR DESCRIPTION
## Summary
- add five new visual themes: glass, plasma, genmoji, neon and holo
- introduce font menu with five typefaces
- remember user preferences for colors and fonts

## Testing
- `node --check conseiller-rgpd.js`
- `php -l conseiller-rgpd.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8ba452f38832ca7c20b1f05d45df9