### PR TITLE
Improve theme palettes and debug panel

### DIFF
--- a/conseiller-rgpd.css
+++ b/conseiller-rgpd.css
@@ -654,16 +654,42 @@ body {
 
 .debug-panel {
     position: fixed;
-    top: 0;
-    right: 0;
-    width: 300px;
-    height: 100%;
+    bottom: 20px;
+    right: 20px;
+    width: 320px;
+    max-height: 50vh;
     background: var(--bg-dark-secondary);
-    border-left: 1px solid var(--border);
+    border: 1px solid var(--border);
     padding: 10px;
     overflow-y: auto;
     z-index: 2000;
     font-size: 12px;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.debug-panel.hidden {
+    display: none;
+}
+
+.debug-panel .debug-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.debug-panel .debug-close {
+    background: none;
+    border: none;
+    color: var(--text-primary);
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+}
+
+.debug-panel .debug-info {
+    margin-bottom: 8px;
 }
 
 /* Responsive design */

--- a/conseiller-rgpd.js
+++ b/conseiller-rgpd.js
@@ -37,6 +37,9 @@ class ConseillerRGPDApp {
         this.themeMenu = document.getElementById('themeMenu');
         this.fontMenu = document.getElementById('fontMenu');
         this.debugPanel = document.getElementById('debugPanel');
+        this.debugContent = document.getElementById('debugContent');
+        this.debugInfo = document.getElementById('debugInfo');
+        this.debugClose = document.getElementById('debugClose');
         
         this.init();
     }
@@ -49,6 +52,8 @@ class ConseillerRGPDApp {
         this.showWelcomeMessage();
         this.focusInput();
         this.updateSendButtonState();
+        this.logAction('Application initialisée');
+        this.updateDebugInfo();
 
         // Mise à jour de l'heure chaque seconde
         setInterval(() => this.updateDateTime(), 1000);
@@ -143,6 +148,10 @@ class ConseillerRGPDApp {
                     this.hideFontMenu();
                 }
             });
+        }
+
+        if (this.debugClose) {
+            this.debugClose.addEventListener('click', () => this.toggleDebug());
         }
 
         // Raccourcis clavier
@@ -642,6 +651,21 @@ Comment puis-je vous accompagner dans votre démarche de conformité RGPD aujour
     toggleDebug() {
         if (this.debugPanel) {
             this.debugPanel.classList.toggle('hidden');
+            if (!this.debugPanel.classList.contains('hidden')) {
+                this.updateDebugInfo();
+            }
+        }
+    }
+
+    updateDebugInfo() {
+        if (this.debugInfo) {
+            const info = [
+                `Version: ${this.config.VERSION}`,
+                `Utilisateur: ${this.config.USER}`,
+                `Thème: ${localStorage.getItem('rgpd_colorTheme') || 'default'}`,
+                `Police: ${localStorage.getItem('rgpd_font') || 'default'}`
+            ];
+            this.debugInfo.innerHTML = info.map(i => `<div>${i}</div>`).join('');
         }
     }
 
@@ -649,11 +673,11 @@ Comment puis-je vous accompagner dans votre démarche de conformité RGPD aujour
         const timestamp = new Date().toLocaleTimeString();
         const entry = `[${timestamp}] ${action}`;
         this.debugLog.push(entry);
-        if (this.debugPanel) {
+        if (this.debugContent) {
             const div = document.createElement('div');
             div.textContent = entry;
-            this.debugPanel.appendChild(div);
-            this.debugPanel.scrollTop = this.debugPanel.scrollHeight;
+            this.debugContent.appendChild(div);
+            this.debugContent.scrollTop = this.debugContent.scrollHeight;
         }
     }
 
@@ -673,6 +697,7 @@ Comment puis-je vous accompagner dans votre démarche de conformité RGPD aujour
         const fontName = fontMap[font] || 'défaut';
         this.showToast(`Police ${fontName} activée`, 'success');
         this.logAction(`Police changée: ${fontName}`);
+        this.updateDebugInfo();
     }
 
     applyColorTheme(themeId, silent = false) {
@@ -684,6 +709,7 @@ Comment puis-je vous accompagner dans votre démarche de conformité RGPD aujour
             this.showToast(`Thème ${theme.name} activé`, 'success');
         }
         this.logAction(`Thème changé: ${theme.name}`);
+        this.updateDebugInfo();
     }
 
     // Méthode pour exporter tout l'historique

--- a/conseiller-rgpd.php
+++ b/conseiller-rgpd.php
@@ -181,7 +181,14 @@ if (isset($_POST['action']) && $_POST['action'] === 'chat') {
     </div>
     
     <div class="toast" id="toast"></div>
-    <div class="debug-panel hidden" id="debugPanel"></div>
+    <div class="debug-panel hidden" id="debugPanel">
+        <div class="debug-header">
+            <span>Debug</span>
+            <button class="debug-close" id="debugClose">&times;</button>
+        </div>
+        <div class="debug-info" id="debugInfo"></div>
+        <div class="debug-content" id="debugContent"></div>
+    </div>
 
     <!-- Configuration JavaScript -->
     <script>

--- a/themes.js
+++ b/themes.js
@@ -24,13 +24,13 @@ window.RGPD_THEMES = [
       '--primary-dark': '#0369a1',
       '--primary-light': '#38bdf8',
       '--secondary': '#0ea5e9',
-      '--bg-dark': 'linear-gradient(135deg, #0f172a 0%, #0e7490 100%)',
-      '--bg-dark-secondary': '#0f172a',
+      '--bg-dark': 'linear-gradient(135deg, #0f172a 0%, #082f49 50%, #0e7490 100%)',
+      '--bg-dark-secondary': '#082f49',
       '--text-primary': '#e0f2fe',
-      '--text-secondary': '#a5f3fc',
-      '--border': '#164e63',
+      '--text-secondary': '#bae6fd',
+      '--border': '#075985',
       '--glass': 'rgba(2, 132, 199, 0.15)',
-      '--glass-border': 'rgba(2, 132, 199, 0.3)'
+      '--glass-border': 'rgba(2, 132, 199, 0.4)'
     }
   },
   {
@@ -41,13 +41,13 @@ window.RGPD_THEMES = [
       '--primary-dark': '#166534',
       '--primary-light': '#4ade80',
       '--secondary': '#065f46',
-      '--bg-dark': 'linear-gradient(135deg, #052e16 0%, #14532d 100%)',
-      '--bg-dark-secondary': '#052e16',
+      '--bg-dark': 'linear-gradient(135deg, #052e16 0%, #166534 50%, #14532d 100%)',
+      '--bg-dark-secondary': '#0a3522',
       '--text-primary': '#dcfce7',
-      '--text-secondary': '#a7f3d0',
-      '--border': '#064e3b',
+      '--text-secondary': '#bbf7d0',
+      '--border': '#14532d',
       '--glass': 'rgba(22, 163, 74, 0.15)',
-      '--glass-border': 'rgba(22, 163, 74, 0.3)'
+      '--glass-border': 'rgba(22, 163, 74, 0.4)'
     }
   },
   {
@@ -58,30 +58,30 @@ window.RGPD_THEMES = [
       '--primary-dark': '#9f1239',
       '--primary-light': '#f472b6',
       '--secondary': '#c2410c',
-      '--bg-dark': 'linear-gradient(135deg, #4c0519 0%, #9f1239 100%)',
-      '--bg-dark-secondary': '#4c0519',
+      '--bg-dark': 'linear-gradient(135deg, #4c0519 0%, #9f1239 50%, #c2410c 100%)',
+      '--bg-dark-secondary': '#5f071f',
       '--text-primary': '#fee2e2',
-      '--text-secondary': '#fecdd3',
-      '--border': '#7f1d1d',
+      '--text-secondary': '#fda4af',
+      '--border': '#9f1239',
       '--glass': 'rgba(190, 18, 60, 0.15)',
-      '--glass-border': 'rgba(190, 18, 60, 0.3)'
+      '--glass-border': 'rgba(190, 18, 60, 0.4)'
     }
   },
   {
     id: 'glass',
     name: 'Glass',
     vars: {
-      '--primary': 'rgba(255, 255, 255, 0.8)',
-      '--primary-dark': 'rgba(255, 255, 255, 0.6)',
+      '--primary': 'rgba(255, 255, 255, 0.9)',
+      '--primary-dark': 'rgba(255, 255, 255, 0.7)',
       '--primary-light': '#ffffff',
-      '--secondary': 'rgba(255, 255, 255, 0.3)',
-      '--bg-dark': 'linear-gradient(135deg, rgba(255,255,255,0.2) 0%, rgba(255,255,255,0.05) 100%)',
-      '--bg-dark-secondary': 'rgba(255,255,255,0.1)',
-      '--text-primary': '#ffffff',
-      '--text-secondary': '#e2e8f0',
-      '--border': 'rgba(255,255,255,0.2)',
-      '--glass': 'rgba(255,255,255,0.2)',
-      '--glass-border': 'rgba(255,255,255,0.3)'
+      '--secondary': 'rgba(255, 255, 255, 0.5)',
+      '--bg-dark': 'rgba(255, 255, 255, 0.5)',
+      '--bg-dark-secondary': 'rgba(255, 255, 255, 0.3)',
+      '--text-primary': '#0f172a',
+      '--text-secondary': '#334155',
+      '--border': 'rgba(0, 0, 0, 0.2)',
+      '--glass': 'rgba(255, 255, 255, 0.4)',
+      '--glass-border': 'rgba(0, 0, 0, 0.2)'
     }
   },
   {
@@ -92,13 +92,13 @@ window.RGPD_THEMES = [
       '--primary-dark': '#7e22ce',
       '--primary-light': '#d946ef',
       '--secondary': '#06b6d4',
-      '--bg-dark': 'linear-gradient(135deg, #0f172a 0%, #9333ea 50%, #db2777 100%)',
+      '--bg-dark': 'linear-gradient(135deg, #0f172a 0%, #9333ea 40%, #db2777 80%, #06b6d4 100%)',
       '--bg-dark-secondary': '#1e1b4b',
       '--text-primary': '#f3e8ff',
-      '--text-secondary': '#e9d5ff',
-      '--border': '#6b21a8',
+      '--text-secondary': '#f5d0fe',
+      '--border': '#7e22ce',
       '--glass': 'rgba(147, 51, 234, 0.15)',
-      '--glass-border': 'rgba(147, 51, 234, 0.3)'
+      '--glass-border': 'rgba(147, 51, 234, 0.4)'
     }
   },
   {
@@ -109,13 +109,13 @@ window.RGPD_THEMES = [
       '--primary-dark': '#d97706',
       '--primary-light': '#fde68a',
       '--secondary': '#10b981',
-      '--bg-dark': 'linear-gradient(135deg, #0f172a 0%, #f59e0b 25%, #10b981 50%, #3b82f6 75%, #db2777 100%)',
+      '--bg-dark': 'linear-gradient(135deg, #0f172a 0%, #f59e0b 20%, #10b981 40%, #3b82f6 60%, #db2777 80%, #8b5cf6 100%)',
       '--bg-dark-secondary': '#0f172a',
       '--text-primary': '#fef3c7',
       '--text-secondary': '#fde68a',
-      '--border': '#92400e',
+      '--border': '#b45309',
       '--glass': 'rgba(245, 158, 11, 0.15)',
-      '--glass-border': 'rgba(245, 158, 11, 0.3)'
+      '--glass-border': 'rgba(245, 158, 11, 0.4)'
     }
   },
   {
@@ -126,13 +126,13 @@ window.RGPD_THEMES = [
       '--primary-dark': '#0d9488',
       '--primary-light': '#5eead4',
       '--secondary': '#f472b6',
-      '--bg-dark': 'linear-gradient(135deg, #18181b 0%, #0d9488 50%, #f472b6 100%)',
+      '--bg-dark': 'linear-gradient(135deg, #18181b 0%, #0d9488 40%, #f472b6 80%, #2dd4bf 100%)',
       '--bg-dark-secondary': '#18181b',
       '--text-primary': '#ccfbf1',
-      '--text-secondary': '#99f6e4',
-      '--border': '#0f766e',
+      '--text-secondary': '#a7ffeb',
+      '--border': '#0d9488',
       '--glass': 'rgba(20, 184, 166, 0.15)',
-      '--glass-border': 'rgba(20, 184, 166, 0.3)'
+      '--glass-border': 'rgba(20, 184, 166, 0.4)'
     }
   },
   {
@@ -143,13 +143,13 @@ window.RGPD_THEMES = [
       '--primary-dark': '#4f46e5',
       '--primary-light': '#a5b4fc',
       '--secondary': '#ec4899',
-      '--bg-dark': 'linear-gradient(135deg, #0f172a 0%, #4f46e5 50%, #ec4899 100%)',
+      '--bg-dark': 'linear-gradient(135deg, #0f172a 0%, #4f46e5 40%, #ec4899 80%, #6366f1 100%)',
       '--bg-dark-secondary': '#1e1b4b',
       '--text-primary': '#ede9fe',
-      '--text-secondary': '#ddd6fe',
-      '--border': '#4338ca',
+      '--text-secondary': '#e0e7ff',
+      '--border': '#4f46e5',
       '--glass': 'rgba(99, 102, 241, 0.15)',
-      '--glass-border': 'rgba(99, 102, 241, 0.3)'
+      '--glass-border': 'rgba(99, 102, 241, 0.4)'
     }
   }
 ];


### PR DESCRIPTION
## Summary
- refine color palettes for all non-default themes and fix glass theme contrast
- convert debug panel to floating window with close button
- debug panel now reports version, user, theme and font

## Testing
- `node -e "global.window={};require('./themes.js');console.log('themes loaded');"`
- `node --check conseiller-rgpd.js && echo 'syntax ok'`
- `php -l conseiller-rgpd.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8c01ee884832cb057a095864eca60