### PR TITLE
Add Symplissime theme and richer debug logging

### DIFF
--- a/conseiller-rgpd.php
+++ b/conseiller-rgpd.php
@@ -105,6 +105,7 @@ if (isset($_POST['action']) && $_POST['action'] === 'chat') {
     <title>Conseiller RGPD IA v<?php echo htmlspecialchars($APP_VERSION); ?> - Powered by Symplissime AI</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&family=Roboto:wght@300;400;500;700&family=Lato:wght@300;400;700&family=Poppins:wght@300;400;500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="conseiller-rgpd.css">
+    <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
 </head>
 <body>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,14 @@
+/* Symplissime theme */
+body.theme-symplissime {
+  --primary: #10b981;
+  --primary-dark: #059669;
+  --primary-light: #34d399;
+  --secondary: #6366f1;
+  --bg-dark: linear-gradient(135deg, #0f172a 0%, #10b981 40%, #6366f1 80%, #ec4899 100%);
+  --bg-dark-secondary: #1e293b;
+  --text-primary: #f0fdf4;
+  --text-secondary: #bbf7d0;
+  --border: #059669;
+  --glass: rgba(16,185,129,0.15);
+  --glass-border: rgba(16,185,129,0.4);
+}

--- a/themes.js
+++ b/themes.js
@@ -151,5 +151,11 @@ window.RGPD_THEMES = [
       '--glass': 'rgba(99, 102, 241, 0.15)',
       '--glass-border': 'rgba(99, 102, 241, 0.4)'
     }
+  },
+  {
+    id: 'symplissime',
+    name: 'Symplissime',
+    class: 'theme-symplissime',
+    vars: {}
   }
 ];


### PR DESCRIPTION
## Summary
- log connection events, errors, and response timings in debug panel without exposing user text
- support class-based themes and add new "Symplissime" option with accompanying stylesheet
- include Symplissime theme assets in application

## Testing
- `node --check conseiller-rgpd.js`
- `php -l conseiller-rgpd.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8c2842bb0832cb5e32b63523581b2