### PR TITLE
Add welcome carousel to chat

### DIFF
--- a/symplissime-ai.css
+++ b/symplissime-ai.css
@@ -893,3 +893,128 @@ body {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+/* Carousel de bienvenue */
+.carousel-container {
+  position: relative;
+  width: 100%;
+  max-width: 400px;
+  overflow: hidden;
+  border-radius: 10px;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+  background-color: #fff;
+  padding: 10px;
+}
+
+.carousel-track {
+  display: flex;
+  transition: transform 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.carousel-item {
+  min-width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  padding: 10px 0;
+}
+
+.carousel-item img {
+  width: 100%;
+  max-width: 300px;
+  height: auto;
+  border-radius: 8px;
+  margin-bottom: 10px;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.05);
+  transition: transform 0.3s ease;
+}
+
+.carousel-item img:hover {
+  transform: scale(1.03);
+}
+
+.item-text h3 {
+  margin: 0 0 5px;
+  font-weight: 600;
+  color: #1e3a8a;
+  font-size: 1rem;
+}
+
+.item-text p {
+  margin: 0;
+  color: #666;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.prev-button,
+.next-button {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  border: none;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 1.2rem;
+  border-radius: 50%;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.prev-button:hover,
+.next-button:hover {
+  background: rgba(0, 0, 0, 0.6);
+  transform: translateY(-50%) scale(1.1);
+}
+
+.prev-button {
+  left: 10px;
+}
+
+.next-button {
+  right: 10px;
+}
+
+.carousel-dots {
+  text-align: center;
+  padding: 5px 0;
+}
+
+.dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  margin: 0 4px;
+  background: #ccc;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.dot.active {
+  background: #1e3a8a;
+}
+
+@media (max-width: 400px) {
+  .carousel-container {
+    padding: 5px;
+    border-radius: 8px;
+  }
+
+  .carousel-item img {
+    max-width: 250px;
+  }
+
+  .item-text h3 {
+    font-size: 0.9rem;
+  }
+
+  .item-text p {
+    font-size: 0.7rem;
+  }
+
+  .prev-button,
+  .next-button {
+    padding: 6px 10px;
+    font-size: 1rem;
+  }
+}

--- a/symplissime-ai.js
+++ b/symplissime-ai.js
@@ -547,8 +547,155 @@ Comment puis-je vous assister aujourd'hui dans votre support technique ?`;
 
         setTimeout(async () => {
             await this.streamMessage(welcomeMessage);
+            this.insertCarousel();
             this.updateStatus(true, 'Connecté');
         }, 1000);
+    }
+
+    insertCarousel() {
+        const carouselHTML = `
+        <div class="carousel-container" role="region" aria-label="Mini carousel d'ordinateurs portables">
+            <div class="carousel-track" role="list">
+                <div class="carousel-item" role="listitem" aria-label="Slide 1: Elegant Laptop">
+                    <img loading="lazy" src="https://images.pexels.com/photos/40185/mac-freelancer-macintosh-macbook-40185.jpeg?auto=compress&cs=tinysrgb&w=800&h=600&dpr=1" alt="Ordinateur Portable 1">
+                    <div class="item-text">
+                        <h3>Portable Élégant</h3>
+                        <p>Design moderne pour pros.</p>
+                    </div>
+                </div>
+                <div class="carousel-item" role="listitem" aria-label="Slide 2: High Performance Laptop">
+                    <img loading="lazy" src="https://placehold.co/600x400/d97706/ffffff?text=Laptop+2" alt="Ordinateur Portable 2">
+                    <div class="item-text">
+                        <h3>Laptop Performant</h3>
+                        <p>Idéal pour gaming et vidéo.</p>
+                    </div>
+                </div>
+                <div class="carousel-item" role="listitem" aria-label="Slide 3: Lightweight Ultrabook">
+                    <img loading="lazy" src="https://placehold.co/600x400/059669/ffffff?text=Laptop+3" alt="Ordinateur Portable 3">
+                    <div class="item-text">
+                        <h3>Ultrabook Léger</h3>
+                        <p>Parfait pour la portabilité.</p>
+                    </div>
+                </div>
+            </div>
+            <button class="prev-button" aria-label="Diapositive précédente">‹</button>
+            <button class="next-button" aria-label="Diapositive suivante">›</button>
+            <div class="carousel-dots">
+                <span class="dot active" data-index="0"></span>
+                <span class="dot" data-index="1"></span>
+                <span class="dot" data-index="2"></span>
+            </div>
+        </div>`;
+
+        const wrapper = this.createMessageElement('', false, false);
+        const messageDiv = wrapper.querySelector('.message');
+        messageDiv.innerHTML = DOMPurify.sanitize(carouselHTML);
+
+        this.initCarousel(wrapper.querySelector('.carousel-container'));
+    }
+
+    initCarousel(container) {
+        if (!container) return;
+        const track = container.querySelector('.carousel-track');
+        const items = Array.from(container.querySelectorAll('.carousel-item'));
+        const prevButton = container.querySelector('.prev-button');
+        const nextButton = container.querySelector('.next-button');
+        const dots = container.querySelectorAll('.dot');
+        let currentIndex = 0;
+        let autoplayInterval = null;
+
+        const updateCarousel = () => {
+            const itemWidth = items[0].getBoundingClientRect().width;
+            track.style.transform = `translateX(-${currentIndex * itemWidth}px)`;
+            updateDots();
+        };
+
+        const updateDots = () => {
+            dots.forEach((dot, index) => {
+                dot.classList.toggle('active', index === currentIndex);
+            });
+        };
+
+        const startAutoplay = () => {
+            autoplayInterval = setInterval(() => {
+                currentIndex = (currentIndex + 1) % items.length;
+                updateCarousel();
+            }, 3000);
+        };
+
+        const stopAutoplay = () => {
+            clearInterval(autoplayInterval);
+        };
+
+        nextButton.addEventListener('click', () => {
+            currentIndex = (currentIndex + 1) % items.length;
+            updateCarousel();
+            stopAutoplay();
+            startAutoplay();
+        });
+
+        prevButton.addEventListener('click', () => {
+            currentIndex = (currentIndex - 1 + items.length) % items.length;
+            updateCarousel();
+            stopAutoplay();
+            startAutoplay();
+        });
+
+        dots.forEach(dot => {
+            dot.addEventListener('click', () => {
+                currentIndex = parseInt(dot.getAttribute('data-index'));
+                updateCarousel();
+                stopAutoplay();
+                startAutoplay();
+            });
+        });
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'ArrowRight') {
+                currentIndex = (currentIndex + 1) % items.length;
+                updateCarousel();
+                stopAutoplay();
+                startAutoplay();
+            } else if (e.key === 'ArrowLeft') {
+                currentIndex = (currentIndex - 1 + items.length) % items.length;
+                updateCarousel();
+                stopAutoplay();
+                startAutoplay();
+            }
+        });
+
+        let touchStartX = 0;
+        let touchEndX = 0;
+        track.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        track.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            if (touchStartX - touchEndX > 50) {
+                currentIndex = (currentIndex + 1) % items.length;
+                updateCarousel();
+                stopAutoplay();
+                startAutoplay();
+            } else if (touchEndX - touchStartX > 50) {
+                currentIndex = (currentIndex - 1 + items.length) % items.length;
+                updateCarousel();
+                stopAutoplay();
+                startAutoplay();
+            }
+        });
+
+        container.addEventListener('mouseenter', stopAutoplay);
+        container.addEventListener('mouseleave', startAutoplay);
+
+        if (items.length <= 1) {
+            prevButton.style.display = 'none';
+            nextButton.style.display = 'none';
+            container.querySelector('.carousel-dots').style.display = 'none';
+        }
+
+        updateCarousel();
+        updateDots();
+        startAutoplay();
     }
 
     updateDateTime() {


### PR DESCRIPTION
## Summary
- display a small laptop carousel right after the initial welcome message
- style carousel and add JS behavior (navigation, autoplay, accessibility)

## Testing
- `php -l symplissime-ai.php`
- `node --check symplissime-ai.js && echo "Syntax OK"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d57b18a0832c907a89e40100950d