### PR TITLE
Refine carousel suggestions and fix highlight.js import

### DIFF
--- a/symplissime-ai.css
+++ b/symplissime-ai.css
@@ -894,16 +894,16 @@ body {
   100% { transform: rotate(360deg); }
 }
 
-/* Carousel de bienvenue */
+/* Mini carousel suggestions */
 .carousel-container {
   position: relative;
   width: 100%;
-  max-width: 400px;
+  max-width: 260px;
   overflow: hidden;
-  border-radius: 10px;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
   background-color: #fff;
-  padding: 10px;
+  padding: 6px;
 }
 
 .carousel-track {
@@ -915,15 +915,15 @@ body {
   min-width: 100%;
   box-sizing: border-box;
   text-align: center;
-  padding: 10px 0;
+  padding: 5px 0;
 }
 
 .carousel-item img {
   width: 100%;
-  max-width: 300px;
+  max-width: 220px;
   height: auto;
-  border-radius: 8px;
-  margin-bottom: 10px;
+  border-radius: 6px;
+  margin-bottom: 6px;
   box-shadow: 0 3px 8px rgba(0, 0, 0, 0.05);
   transition: transform 0.3s ease;
 }
@@ -933,17 +933,17 @@ body {
 }
 
 .item-text h3 {
-  margin: 0 0 5px;
+  margin: 0 0 4px;
   font-weight: 600;
   color: #1e3a8a;
-  font-size: 1rem;
+  font-size: 0.9rem;
 }
 
 .item-text p {
   margin: 0;
   color: #666;
-  font-size: 0.8rem;
-  line-height: 1.4;
+  font-size: 0.75rem;
+  line-height: 1.3;
 }
 
 .prev-button,
@@ -954,9 +954,9 @@ body {
   background: rgba(0, 0, 0, 0.4);
   color: #fff;
   border: none;
-  padding: 8px 12px;
+  padding: 4px 8px;
   cursor: pointer;
-  font-size: 1.2rem;
+  font-size: 1rem;
   border-radius: 50%;
   transition: background 0.3s ease, transform 0.3s ease;
 }
@@ -982,9 +982,9 @@ body {
 
 .dot {
   display: inline-block;
-  width: 8px;
-  height: 8px;
-  margin: 0 4px;
+  width: 6px;
+  height: 6px;
+  margin: 0 3px;
   background: #ccc;
   border-radius: 50%;
   cursor: pointer;
@@ -996,16 +996,15 @@ body {
 
 @media (max-width: 400px) {
   .carousel-container {
-    padding: 5px;
-    border-radius: 8px;
+    padding: 4px;
   }
 
   .carousel-item img {
-    max-width: 250px;
+    max-width: 180px;
   }
 
   .item-text h3 {
-    font-size: 0.9rem;
+    font-size: 0.85rem;
   }
 
   .item-text p {
@@ -1014,7 +1013,13 @@ body {
 
   .prev-button,
   .next-button {
-    padding: 6px 10px;
-    font-size: 1rem;
+    padding: 4px 8px;
+    font-size: 0.9rem;
   }
+}
+
+.carousel-question {
+  margin-bottom: 6px;
+  font-weight: 500;
+  font-size: 0.9rem;
 }

--- a/symplissime-ai.js
+++ b/symplissime-ai.js
@@ -289,6 +289,7 @@ class SymplissimeAIApp {
     }
 
     async sendMessage(message) {
+        const includeCarousel = message.toLowerCase().includes('portable');
         this.addMessage(message, true);
         this.showTyping();
         this.setProcessingState(true);
@@ -319,6 +320,9 @@ class SymplissimeAIApp {
             } else if (data.success && data.message) {
                 // Utiliser l'effet de streaming pour afficher la réponse
                 await this.streamMessage(data.message);
+                if (includeCarousel) {
+                    this.insertCarousel(true);
+                }
                 this.updateStatus(true, 'Connecté');
             } else {
                 this.addMessage('Aucune réponse reçue du serveur', false, true);
@@ -547,34 +551,32 @@ Comment puis-je vous assister aujourd'hui dans votre support technique ?`;
 
         setTimeout(async () => {
             await this.streamMessage(welcomeMessage);
-            this.insertCarousel();
             this.updateStatus(true, 'Connecté');
         }, 1000);
     }
-
-    insertCarousel() {
+    insertCarousel(withQuestion = false) {
         const carouselHTML = `
         <div class="carousel-container" role="region" aria-label="Mini carousel d'ordinateurs portables">
             <div class="carousel-track" role="list">
                 <div class="carousel-item" role="listitem" aria-label="Slide 1: Elegant Laptop">
-                    <img loading="lazy" src="https://images.pexels.com/photos/40185/mac-freelancer-macintosh-macbook-40185.jpeg?auto=compress&cs=tinysrgb&w=800&h=600&dpr=1" alt="Ordinateur Portable 1">
+                    <img loading="lazy" src="https://images.pexels.com/photos/40185/mac-freelancer-macintosh-macbook-40185.jpeg?auto=compress&cs=tinysrgb&h=150" alt="Ordinateur Portable 1">
                     <div class="item-text">
                         <h3>Portable Élégant</h3>
                         <p>Design moderne pour pros.</p>
                     </div>
                 </div>
                 <div class="carousel-item" role="listitem" aria-label="Slide 2: High Performance Laptop">
-                    <img loading="lazy" src="https://placehold.co/600x400/d97706/ffffff?text=Laptop+2" alt="Ordinateur Portable 2">
+                    <img loading="lazy" src="https://placehold.co/240x150/d97706/ffffff?text=Laptop+2" alt="Ordinateur Portable 2">
                     <div class="item-text">
                         <h3>Laptop Performant</h3>
-                        <p>Idéal pour gaming et vidéo.</p>
+                        <p>Pour gaming et vidéo.</p>
                     </div>
                 </div>
                 <div class="carousel-item" role="listitem" aria-label="Slide 3: Lightweight Ultrabook">
-                    <img loading="lazy" src="https://placehold.co/600x400/059669/ffffff?text=Laptop+3" alt="Ordinateur Portable 3">
+                    <img loading="lazy" src="https://placehold.co/240x150/059669/ffffff?text=Laptop+3" alt="Ordinateur Portable 3">
                     <div class="item-text">
                         <h3>Ultrabook Léger</h3>
-                        <p>Parfait pour la portabilité.</p>
+                        <p>Parfaitement portable.</p>
                     </div>
                 </div>
             </div>
@@ -587,9 +589,13 @@ Comment puis-je vous assister aujourd'hui dans votre support technique ?`;
             </div>
         </div>`;
 
+        const content = withQuestion
+            ? `<p class="carousel-question">Avez-vous besoin de matériel ?</p>${carouselHTML}`
+            : carouselHTML;
+
         const wrapper = this.createMessageElement('', false, false);
         const messageDiv = wrapper.querySelector('.message');
-        messageDiv.innerHTML = DOMPurify.sanitize(carouselHTML);
+        messageDiv.innerHTML = DOMPurify.sanitize(content);
 
         this.initCarousel(wrapper.querySelector('.carousel-container'));
     }

--- a/symplissime-ai.php
+++ b/symplissime-ai.php
@@ -177,7 +177,7 @@ if (isset($_POST['action']) && $_POST['action'] === 'chat') {
     </script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/lib/common.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/highlight.min.js"></script>
     <script src="symplissime-ai.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Make the laptop carousel a compact chat suggestion with optional question
- Show carousel only when prompt mentions "portable"
- Replace Node highlight.js build with browser-compatible script

## Testing
- `php -l symplissime-ai.php`
- `npx eslint symplissime-ai.js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d897dd34832ca5901edeb9e94ddf