### PR TITLE
Include API key for document upload

### DIFF
--- a/symplissime-ai.js
+++ b/symplissime-ai.js
@@ -355,9 +355,16 @@ class SymplissimeAIApp {
         this.updateStatus('processing', 'Upload du fichier', 0);
 
         try {
+            // Include API key if provided to avoid unauthorized errors
+            const headers = {};
+            if (this.config.API_KEY) {
+                headers['Authorization'] = `Bearer ${this.config.API_KEY}`;
+            }
+
             const response = await fetch(this.uploadApiUrl, {
                 method: 'POST',
-                body: formData
+                body: formData,
+                headers
             });
 
             if (!response.ok) {

--- a/symplissime-ai.php
+++ b/symplissime-ai.php
@@ -175,7 +175,8 @@ if (isset($_POST['action']) && $_POST['action'] === 'chat') {
         window.SYMPLISSIME_CONFIG = {
             WORKSPACE: '<?php echo $DEFAULT_WORKSPACE; ?>',
             USER: '<?php echo htmlspecialchars($CURRENT_USER); ?>',
-            API_ENDPOINT: '<?php echo $_SERVER['PHP_SELF']; ?>'
+            API_ENDPOINT: '<?php echo $_SERVER['PHP_SELF']; ?>',
+            API_KEY: '<?php echo $API_KEY; ?>'
         };
     </script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>


### PR DESCRIPTION
## Summary
- pass API key through config and authorize upload requests
- avoid forbidden errors when uploading documents

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l symplissime-ai.php`
- `node --check symplissime-ai.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8e56a33b0832c82ec0e3099747473