### PR TITLE
Handle 403 upload errors and document API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Symplissime AI
+
+Ce projet fournit une interface JavaScript pour discuter avec Symplissime AI et téléverser des documents.
+
+## Configuration de la clé API
+
+Avant de charger `symplissime-ai.js`, définissez l'objet global `SYMPLISSIME_CONFIG` pour fournir vos identifiants :
+
+```html
+<script>
+  window.SYMPLISSIME_CONFIG = {
+    API_KEY: 'votre_cle_api',
+    WORKSPACE: 'votre_workspace',
+    USER: 'votre_utilisateur'
+  };
+</script>
+```
+
+La clé API est requise pour l'upload de fichiers. Une erreur 403 indiquera que les identifiants sont manquants ou invalides.

--- a/symplissime-ai.js
+++ b/symplissime-ai.js
@@ -5,6 +5,9 @@
 
 class SymplissimeAIApp {
     constructor() {
+        // Provide credentials like API_KEY via the global SYMPLISSIME_CONFIG
+        // object before loading this script, e.g.:
+        // window.SYMPLISSIME_CONFIG = { API_KEY: 'votre_cle', WORKSPACE: 'id', USER: 'nom' };
         this.config = window.SYMPLISSIME_CONFIG || {};
         this.fontScale = 1;
         this.isProcessing = false;
@@ -367,11 +370,23 @@ class SymplissimeAIApp {
                 headers
             });
 
+            const responseBody = await response.text();
+            console.log('Upload response body:', responseBody);
+
+            if (response.status === 403) {
+                this.addMessage('Accès refusé : clé API manquante ou invalide.', false, true);
+                this.updateStatus('error', 'Clé API invalide');
+                return;
+            }
+
             if (!response.ok) {
                 throw new Error(`Erreur HTTP: ${response.status}`);
             }
 
-            const data = await response.json().catch(() => ({}));
+            let data = {};
+            try {
+                data = JSON.parse(responseBody);
+            } catch (e) {}
             const docId = data.documentId || data.id || '';
             const info = docId
                 ? `📄 Fichier ${file.name} téléchargé (ID: ${docId})`


### PR DESCRIPTION
## Summary
- handle 403 errors in file upload with helpful message
- log upload response body for debugging
- document API key configuration in code and README

## Testing
- `node --check symplissime-ai.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68a8e8827ee0832c97fbf82472f1e97c