### PR TITLE
Add Rainbow theme, feedback thumbs, and easter egg list

### DIFF
--- a/conseiller-rgpd.css
+++ b/conseiller-rgpd.css
@@ -427,6 +427,7 @@ body {
 .message-content {
     flex: 1;
     max-width: 75%;
+    position: relative;
 }
 
 .message {
@@ -477,6 +478,34 @@ body {
 .message-wrapper:hover .message-actions {
     opacity: 1;
     transform: translateY(0);
+}
+
+.feedback-buttons {
+    position: absolute;
+    top: 8px;
+    right: -45px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.feedback-btn {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--glass);
+    border: 1px solid var(--glass-border);
+    color: var(--text-secondary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background 0.3s, color 0.3s;
+}
+
+.feedback-btn:hover {
+    background: var(--primary);
+    color: var(--text-primary);
 }
 
 .action-btn {

--- a/conseiller-rgpd.js
+++ b/conseiller-rgpd.js
@@ -36,6 +36,7 @@ class ConseillerRGPDApp {
             'Chaque commit te rapproche de la gloire.',
             'Un refactor intelligent évite des larmes.'
         ];
+        this.easterEggs = ['confettis', 'darkflip', 'fortune', 'matrix', 'cameleon'];
         // Cache frequently accessed DOM elements
         this.messageInput = document.getElementById('messageInput');
         this.sendButton = document.getElementById('sendButton');
@@ -324,6 +325,9 @@ class ConseillerRGPDApp {
             case 'cameleon':
                 this.cameleon();
                 return true;
+            case 'eastereggs':
+                this.listEasterEggs();
+                return true;
             default:
                 this.showToast('Commande inconnue', 'warning');
                 return true;
@@ -404,6 +408,11 @@ class ConseillerRGPDApp {
         }, 10000);
     }
 
+    listEasterEggs() {
+        const list = this.easterEggs.map(cmd => `/${cmd}`).join(', ');
+        this.addMessage(`🥚 Easter eggs disponibles : ${list}`, false, false);
+    }
+
     addMessage(content, isUser = false, isError = false) {
         const chatMessages = this.chatMessages;
         if (!chatMessages) return;
@@ -438,9 +447,11 @@ class ConseillerRGPDApp {
         }
         
         messageContent.appendChild(message);
-        
-        // Actions pour les messages du bot (non-erreur)
+
+        // Feedback et actions pour les messages du bot (non-erreur)
         if (!isUser && !isError) {
+            const feedback = this.createFeedbackButtons();
+            messageContent.appendChild(feedback);
             const actions = this.createMessageActions(content);
             messageContent.appendChild(actions);
         }
@@ -506,6 +517,27 @@ class ConseillerRGPDApp {
             }
             this.logAction('Réponse bot terminée');
         }
+    }
+
+    createFeedbackButtons() {
+        const container = document.createElement('div');
+        container.className = 'feedback-buttons';
+
+        const up = document.createElement('button');
+        up.className = 'feedback-btn';
+        up.textContent = '👍';
+        up.title = 'Réponse satisfaisante';
+        up.onclick = () => this.showToast('Merci pour votre retour !', 'success');
+
+        const down = document.createElement('button');
+        down.className = 'feedback-btn';
+        down.textContent = '👎';
+        down.title = 'Réponse insuffisante';
+        down.onclick = () => this.showToast('Merci pour votre retour !', 'error');
+
+        container.appendChild(up);
+        container.appendChild(down);
+        return container;
     }
 
     createMessageActions(content) {

--- a/themes.js
+++ b/themes.js
@@ -154,7 +154,7 @@ window.RGPD_THEMES = [
   },
   {
     id: 'rainbow',
-    name: 'Arc-en-ciel',
+    name: 'RAINBOW',
     vars: {
       '--primary': '#ff0000',
       '--primary-dark': '#b30000',


### PR DESCRIPTION
## Summary
- Display new RAINBOW color theme in theme dropdown
- Add floating thumbs up/down feedback buttons on bot responses
- Introduce /eastereggs command listing available Easter eggs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e6611eac832ca54ff3f6f582d0d4