### PR TITLE
feat: add rainbow theme and chat easter eggs

### DIFF
--- a/symplissimeai.css
+++ b/symplissimeai.css
@@ -182,6 +182,27 @@
   --fluent-shadow-container: 0 2px 8px rgba(45, 212, 191, 0.14);
 }
 
+[data-theme="rainbow-theme"] {
+  --c-pri: #ff0080;
+  --c-pri-light: #ff8c00;
+  --c-pri-dark: #8b00ff;
+  --c-bg: #fff;
+  --c-bg-hover: #fff0ff;
+  --c-border: #ffd9ff;
+  --c-shadow: 0 4px 30px #ff00ff22, 0 1.5px 6px #ff00ff18;
+  --c-table-odd: #fff0f5;
+  --c-table-even: #ffe6ff;
+  --fluent-primary: var(--c-pri);
+  --fluent-text-color: var(--c-pri);
+  --fluent-border-color-light: var(--c-border);
+  --fluent-border-color-accent: var(--c-pri-light);
+  --fluent-background-light: #fff0f5;
+  --fluent-hover-background: var(--c-bg-hover);
+  --fluent-active-background: #ffd6ff;
+  --fluent-shadow-container: 0 2px 8px rgba(255, 0, 255, 0.14);
+  --chat-bg: linear-gradient(90deg, red, orange, yellow, green, blue, indigo, violet);
+}
+
 * {
   box-sizing: border-box;
 }
@@ -339,6 +360,10 @@ body {
   background: linear-gradient(135deg, #0d9488 0%, #5eead4 100%);
 }
 
+.theme-preview.rainbow::before {
+  background: linear-gradient(135deg, red, orange, yellow, green, blue, indigo, violet);
+}
+
 .theme-option:hover .theme-preview::before {
   transform: scale(1.2) rotate(15deg);
   box-shadow: 0 0 8px rgba(0,0,0,0.3);
@@ -347,6 +372,102 @@ body {
 .theme-option.active .theme-preview::before {
   transform: scale(1.1);
   box-shadow: 0 0 0 2px #fff, 0 0 8px rgba(0,0,0,0.4);
+}
+
+/* Feedback thumbs */
+.message-feedback {
+  margin-left: auto;
+  display: flex;
+  gap: 4px;
+}
+
+.thumb {
+  cursor: pointer;
+  animation: floatThumb 2s ease-in-out infinite alternate;
+}
+
+@keyframes floatThumb {
+  from { transform: translateY(0); }
+  to { transform: translateY(-4px); }
+}
+
+/* Confetti */
+.confetti-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 1000;
+}
+
+.confetti {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  opacity: 0.8;
+  animation: confetti-fall 5s linear forwards;
+}
+
+@keyframes confetti-fall {
+  from { transform: translateY(-10vh) rotate(0deg); }
+  to { transform: translateY(110vh) rotate(720deg); }
+}
+
+/* Matrix */
+.matrix-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: hidden;
+  background: rgba(0,0,0,0.9);
+  z-index: 1000;
+}
+
+.matrix-container span {
+  position: absolute;
+  top: -20px;
+  color: #0f0;
+  font-family: monospace;
+  animation: matrix-fall 5s linear infinite;
+}
+
+@keyframes matrix-fall {
+  from { transform: translateY(-100%); }
+  to { transform: translateY(100vh); }
+}
+
+/* Cameleon mode */
+#chatContainer.cameleon-mode {
+  background: linear-gradient(90deg, red, orange, yellow, green, blue, indigo, violet);
+  position: relative;
+}
+
+#chatContainer.cameleon-mode .message.bot {
+  animation: cam-color 2s infinite alternate;
+}
+
+@keyframes cam-color {
+  from { background-color: var(--c-pri-light); }
+  to { background-color: var(--c-pri-dark); }
+}
+
+.cameleon-mascot {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  font-size: 2rem;
+  animation: bounce 1s infinite alternate;
+}
+
+@keyframes bounce {
+  from { transform: translateY(0); }
+  to { transform: translateY(-5px); }
 }
 
 /* BRANDING SYMPLISSIME */

--- a/symplissimeai.js
+++ b/symplissimeai.js
@@ -48,6 +48,11 @@ class SymplissimeAIApp {
                 name: 'Midnight Dark',
                 icon: '🌙',
                 attribute: 'midnight-dark'
+            },
+            'rainbow': {
+                name: 'Rainbow',
+                icon: '🌈',
+                attribute: 'rainbow-theme'
             }
         };
 
@@ -73,6 +78,8 @@ class SymplissimeAIApp {
                 css: "'Montserrat', sans-serif"
             }
         };
+
+        this.easterEggs = ['/confettis','/darkflip','/fortune','/matrix','/cameleon','/eastereggs'];
         
         this.init();
     }
@@ -402,7 +409,7 @@ class SymplissimeAIApp {
 
         const messageInput = this.getMessageInput();
         const message = messageInput.value.trim();
-        
+
         if (!message) {
             this.showToast('Veuillez saisir un message', 'warning');
             return;
@@ -413,9 +420,45 @@ class SymplissimeAIApp {
             return;
         }
 
+        if (message.startsWith('/')) {
+            if (this.handleCommand(message)) {
+                messageInput.value = '';
+                return;
+            }
+        }
+
         messageInput.value = '';
         this.addPromptSuggestion(message);
         await this.sendMessage(message);
+    }
+
+    handleCommand(cmd) {
+        const command = cmd.slice(1).toLowerCase();
+        switch (command) {
+            case 'confettis':
+                this.launchConfetti();
+                this.showToast('🎉 Party time!');
+                return true;
+            case 'darkflip':
+                this.darkFlip();
+                return true;
+            case 'fortune':
+                this.showFortune();
+                return true;
+            case 'matrix':
+                this.launchMatrix();
+                this.showToast('💻 Welcome to the Matrix');
+                return true;
+            case 'cameleon':
+                this.cameleonMode();
+                this.showToast('🦎 Le caméléon vous observe…');
+                return true;
+            case 'eastereggs':
+                this.addMessage(`Easter Eggs disponibles: ${this.easterEggs.join(', ')}`, false);
+                return true;
+            default:
+                return false;
+        }
     }
 
     async sendMessage(message) {
@@ -644,12 +687,92 @@ class SymplissimeAIApp {
         emailBtn.className = 'action-btn';
         emailBtn.innerHTML = '📧 Email';
         emailBtn.onclick = () => this.sendByEmail(content);
-        
+
+        const feedback = document.createElement('div');
+        feedback.className = 'message-feedback';
+        const up = document.createElement('span');
+        up.className = 'thumb thumb-up';
+        up.textContent = '👍';
+        up.onclick = () => this.showToast('Merci pour votre retour!');
+        const down = document.createElement('span');
+        down.className = 'thumb thumb-down';
+        down.textContent = '👎';
+        down.onclick = () => this.showToast('Merci pour votre retour!');
+        feedback.appendChild(up);
+        feedback.appendChild(down);
+
         actions.appendChild(copyBtn);
         actions.appendChild(saveBtn);
         actions.appendChild(emailBtn);
-        
+        actions.appendChild(feedback);
+
         return actions;
+    }
+
+    launchConfetti() {
+        const container = document.createElement('div');
+        container.className = 'confetti-container';
+        for (let i = 0; i < 100; i++) {
+            const confetti = document.createElement('div');
+            confetti.className = 'confetti';
+            confetti.style.left = Math.random() * 100 + '%';
+            confetti.style.backgroundColor = `hsl(${Math.random() * 360},100%,50%)`;
+            confetti.style.animationDelay = Math.random() * 3 + 's';
+            container.appendChild(confetti);
+        }
+        document.body.appendChild(container);
+        setTimeout(() => container.remove(), 5000);
+    }
+
+    darkFlip() {
+        const original = this.currentTheme;
+        const target = original === 'dark' ? 'symplissime' : 'dark';
+        this.applyTheme(target);
+        this.showToast(target === 'dark' ? '🌙 Mode secret activé' : '☀️ Retour à la normale');
+        setTimeout(() => {
+            this.applyTheme(original);
+            this.showToast(original === 'dark' ? '🌙 Mode secret activé' : '☀️ Retour à la normale');
+        }, 5000);
+    }
+
+    showFortune() {
+        const fortunes = [
+            'Une sauvegarde réussie illumine ta journée.',
+            'Chaque bug est une chance de briller.',
+            'Un redémarrage bien placé vaut mille correctifs.',
+            'La patience est la meilleure optimisation.',
+            'Les logs conduisent à la sagesse.'
+        ];
+        const fortune = fortunes[Math.floor(Math.random() * fortunes.length)];
+        this.addMessage(`(Easter Egg) ${fortune}`, false);
+    }
+
+    launchMatrix() {
+        const container = document.createElement('div');
+        container.className = 'matrix-container';
+        for (let i = 0; i < 100; i++) {
+            const span = document.createElement('span');
+            span.textContent = Math.random() > 0.5 ? '0' : '1';
+            span.style.left = Math.random() * 100 + '%';
+            span.style.animationDelay = Math.random() * 5 + 's';
+            container.appendChild(span);
+        }
+        document.body.appendChild(container);
+        setTimeout(() => container.remove(), 8000);
+    }
+
+    cameleonMode() {
+        const container = document.getElementById('chatContainer');
+        if (!container) return;
+        container.classList.add('cameleon-mode');
+        const mascot = document.createElement('div');
+        mascot.className = 'cameleon-mascot';
+        mascot.textContent = '🦎';
+        container.appendChild(mascot);
+        setTimeout(() => {
+            container.classList.remove('cameleon-mode');
+            mascot.remove();
+        }, 10000);
     }
 
     showTyping() {


### PR DESCRIPTION
## Summary
- add rainbow color scheme with theme selector entry
- implement local slash commands with fun UI easter eggs
- ask for feedback on answers with floating thumbs

## Testing
- `node --check symplissimeai.js`

------
https://chatgpt.com/codex/tasks/task_e_68aacf045c18832c83c5ea5b24f04e47