### PR TITLE
Sanitize and clean chat HTML output

### DIFF
--- a/symplissime-ai.php
+++ b/symplissime-ai.php
@@ -167,6 +167,8 @@ if (isset($_POST['action']) && $_POST['action'] === 'chat') {
     </script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/string-strip-html/dist/string-strip-html.umd.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html-clean/dist/html-clean.min.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/highlight.min.js"></script>
     <script src="symplissimeai.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- sanitize markdown output with DOMPurify, string-strip-html, and html-clean
- use helper to remove redundant whitespace before streaming and rendering
- include new libraries in PHP template

## Testing
- `php -l symplissime-ai.php`
- `node --check symplissimeai.js`


------
https://chatgpt.com/codex/tasks/task_e_68aad9958f60832caa2ddfe924af420d