### PR TITLE
Reduce chat response line breaks

### DIFF
--- a/symplissimeai.css
+++ b/symplissimeai.css
@@ -897,6 +897,12 @@ body {
   text-align: center;
 }
 
+.message p,
+.message ul,
+.message ol {
+  margin: 0.25em 0;
+}
+
 /* MESSAGE ACTIONS */
 .message-actions {
   display: flex;

--- a/symplissimeai.js
+++ b/symplissimeai.js
@@ -605,6 +605,7 @@ class SymplissimeAIApp {
             html = htmlClean(html);
         }
         html = html
+            .replace(/(<br\s*\/?>\s*){2,}/g, '<br>')
             .replace(/\n{2,}/g, '\n')
             .replace(/[\t ]{2,}/g, ' ');
         return html.trim();


### PR DESCRIPTION
## Summary
- compress repeated HTML break tags during markdown rendering
- tighten paragraph and list spacing within chat messages

## Testing
- `php -l symplissime-ai.php`
- `node --check symplissimeai.js`


------
https://chatgpt.com/codex/tasks/task_e_68aadace220c832cafc6b80e7dc72a2e