### PR TITLE
Handle blank lines consistently in markdown renderer

### DIFF
--- a/symplissimeai.js
+++ b/symplissimeai.js
@@ -599,14 +599,17 @@ class SymplissimeAIApp {
                 trimOnlySpaces: true
             }).result;
         }
+        processed = processed
+            .replace(/\r\n/g, '\n')
+            .replace(/\n{2,}/g, '\n');
         let html = marked.parse(processed);
         html = DOMPurify.sanitize(html);
         if (typeof htmlClean === 'function') {
             html = htmlClean(html);
         }
         html = html
+            .replace(/<p>\s*<\/p>/g, '')
             .replace(/(<br\s*\/?>\s*){2,}/g, '<br>')
-            .replace(/\n{2,}/g, '\n')
             .replace(/[\t ]{2,}/g, ' ');
         return html.trim();
     }


### PR DESCRIPTION
## Summary
- Normalize CRLF line endings and collapse consecutive blank lines before invoking the Markdown parser
- Strip empty `<p>` tags and collapse repeated `<br>` elements after HTML generation to keep single spacing

## Testing
- `node -e "const marked={parse:s=>'<p>'+s.replace(/\n/g,'<br>')+'</p>'}; const DOMPurify={sanitize:s=>s}; function htmlClean(s){return s;} function generateHTML(content){ let processed=content; processed=processed.replace(/\r\n/g,'\n').replace(/\n{2,}/g,'\n'); let html=marked.parse(processed); html=DOMPurify.sanitize(html); html=html.replace(/<p>\s*<\/p>/g,'').replace(/(<br\s*\/?>\s*){2,}/g,'<br>').replace(/[\t ]{2,}/g,' '); return html.trim(); } const inputs=['Line1\r\n\r\nLine2','Line1\n\n\nLine2','\r\nLine1\r\n\r\nLine2\r\n','Line1\n\n\n\n']; inputs.forEach((i,idx)=>{console.log('case'+idx+':'); console.log(generateHTML(i));});"`

------
https://chatgpt.com/codex/tasks/task_e_68aadeafcb40832cbbc3aaf65edcf30b