### PR TITLE
Improve message formatting and streaming

### DIFF
--- a/symplissime-ai.php
+++ b/symplissime-ai.php
@@ -167,8 +167,6 @@ if (isset($_POST['action']) && $_POST['action'] === 'chat') {
     </script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/string-strip-html/dist/string-strip-html.umd.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/html-clean/dist/html-clean.min.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/highlight.min.js"></script>
     <script src="symplissimeai.js"></script>
 </body>

--- a/symplissimeai.css
+++ b/symplissimeai.css
@@ -1191,3 +1191,147 @@ body {
   100% { transform: rotate(360deg); }
 }
 
+/* === CORRECTIONS DE FORMATAGE === */
+
+/* Formatage optimisé des paragraphes */
+.message p.formatted-paragraph {
+    margin: 0 0 0.8em 0;
+    line-height: 1.6;
+}
+
+.message p.formatted-paragraph:last-child {
+    margin-bottom: 0;
+}
+
+/* Suppression des paragraphes vides */
+.message p:empty {
+    display: none;
+}
+
+/* Formatage des listes */
+.message ul.formatted-list,
+.message ol.formatted-list {
+    margin: 0.8em 0;
+    padding-left: 1.5em;
+    line-height: 1.6;
+}
+
+.message ul.formatted-list li,
+.message ol.formatted-list li {
+    margin-bottom: 0.4em;
+    line-height: 1.6;
+}
+
+.message ul.formatted-list li:last-child,
+.message ol.formatted-list li:last-child {
+    margin-bottom: 0;
+}
+
+/* Listes imbriquées */
+.message ul.formatted-list ul,
+.message ul.formatted-list ol,
+.message ol.formatted-list ul,
+.message ol.formatted-list ol {
+    margin-top: 0.4em;
+    margin-bottom: 0;
+}
+
+/* Formatage des titres */
+.message h1, .message h2, .message h3,
+.message h4, .message h5, .message h6 {
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+    line-height: 1.3;
+    font-weight: 600;
+}
+
+.message h1:first-child,
+.message h2:first-child,
+.message h3:first-child {
+    margin-top: 0;
+}
+
+/* Espacement entre différents types d'éléments */
+.message p + ul,
+.message p + ol,
+.message ul + p,
+.message ol + p {
+    margin-top: 0.8em;
+}
+
+/* Formatage des blocs de code */
+.message pre.formatted-code {
+    margin: 1em 0;
+    padding: 1em;
+    background: rgba(0, 0, 0, 0.05);
+    border-radius: 8px;
+    overflow-x: auto;
+    white-space: pre;
+    line-height: 1.5;
+}
+
+[data-theme*="dark"] .message pre.formatted-code {
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.message pre.formatted-code:first-child {
+    margin-top: 0;
+}
+
+.message pre.formatted-code:last-child {
+    margin-bottom: 0;
+}
+
+.message pre.formatted-code code {
+    background: none;
+    padding: 0;
+    font-size: 0.9em;
+    line-height: 1.5;
+}
+
+/* Code inline */
+.message code:not(pre code) {
+    background: rgba(0, 0, 0, 0.08);
+    padding: 0.2em 0.4em;
+    border-radius: 4px;
+    font-size: 0.9em;
+    font-family: var(--font-mono);
+}
+
+[data-theme*="dark"] .message code:not(pre code) {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+/* Blockquotes */
+.message blockquote {
+    margin: 1em 0;
+    padding-left: 1em;
+    border-left: 3px solid var(--c-pri);
+    color: var(--fluent-subtle-text);
+    font-style: italic;
+}
+
+.message blockquote p {
+    margin-bottom: 0.5em;
+}
+
+.message blockquote p:last-child {
+    margin-bottom: 0;
+}
+
+/* Optimisation pour les messages du bot */
+.message.bot {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    hyphens: auto;
+}
+
+/* Reset des marges pour certains éléments consécutifs */
+.message li > p:first-child {
+    margin-top: 0;
+}
+
+.message li > p:last-child {
+    margin-bottom: 0;
+}
+


### PR DESCRIPTION
## Summary
- replace HTML generation with thorough cleaning, sanitization and post-processing
- improve markdown rendering and add formatting utilities
- add CSS rules for paragraph, list and code styling and remove unused scripts

## Testing
- `node --check symplissimeai.js`
- `php -l symplissime-ai.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aae23585a8832c919c892260f67f7e