### PR TITLE
Improve ordered list rendering and numbering

### DIFF
--- a/symplissimeai.css
+++ b/symplissimeai.css
@@ -1209,11 +1209,22 @@ body {
 }
 
 /* Formatage des listes */
+
 .message ul.formatted-list,
 .message ol.formatted-list {
     margin: 0.8em 0;
     padding-left: 1.5em;
     line-height: 1.6;
+}
+
+.message ol.formatted-list {
+    list-style-type: decimal;
+    list-style-position: outside;
+}
+
+.message ol.formatted-list li::marker {
+    font-weight: 600;
+    color: var(--c-pri);
 }
 
 .message ul.formatted-list li,

--- a/symplissimeai.js
+++ b/symplissimeai.js
@@ -633,7 +633,7 @@ class SymplissimeAIApp {
                     'blockquote', 'code', 'pre', 'ol', 'ul', 'li', 'a', 'img', 'table',
                     'thead', 'tbody', 'tr', 'td', 'th', 'hr', 'span', 'div'
                 ],
-                ALLOWED_ATTR: ['href', 'src', 'alt', 'title', 'class', 'id', 'target'],
+                ALLOWED_ATTR: ['href', 'src', 'alt', 'title', 'class', 'id', 'target', 'start', 'value'],
                 ALLOW_DATA_ATTR: false,
                 KEEP_CONTENT: true
             });


### PR DESCRIPTION
## Summary
- Preserve ordered list numbering by allowing `start` and `value` attributes in sanitized HTML
- Enhance ordered list styling for better readability

## Testing
- `node --check symplissimeai.js`
- `php -l symplissime-ai.php`


------
https://chatgpt.com/codex/tasks/task_e_68aae3cf01e8832cb7dec9eb56f0de79