### PR TITLE
Fix dropdown overlap for theme and font selectors

### DIFF
--- a/symplissimeai.css
+++ b/symplissimeai.css
@@ -737,7 +737,8 @@ body {
   align-items: center;
   color: white;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
+  z-index: 10;
   transform-style: preserve-3d;
   transition: transform 0.3s ease;
 }

--- a/symplissimeai.js
+++ b/symplissimeai.js
@@ -208,6 +208,7 @@ class SymplissimeAIApp {
     toggleThemeDropdown() {
         const dropdown = document.getElementById('themeDropdown');
         if (dropdown) {
+            this.hideFontDropdown();
             dropdown.classList.toggle('show');
         }
     }
@@ -244,6 +245,8 @@ class SymplissimeAIApp {
             
             // Afficher un toast avec transition fluide
             this.showToast(`Thème ${this.themes[themeKey].name} appliqué`, 'success');
+
+            this.hideThemeDropdown();
         }
     }
 
@@ -319,6 +322,7 @@ class SymplissimeAIApp {
     toggleFontDropdown() {
         const dropdown = document.getElementById('fontDropdown');
         if (dropdown) {
+            this.hideThemeDropdown();
             dropdown.classList.toggle('show');
         }
     }
@@ -345,6 +349,8 @@ class SymplissimeAIApp {
 
             localStorage.setItem('symplissime_font', fontKey);
             this.showToast(`Police ${this.fonts[fontKey].name} appliquée`, 'success');
+
+            this.hideFontDropdown();
         }
     }
 


### PR DESCRIPTION
## Summary
- Allow header dropdowns to overflow and render above content
- Close other dropdown and hide menu after selecting theme or font

## Testing
- `php -l symplissime-ai.php`
- `node --check symplissimeai.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68ab04c07550832cbce46e194c89c175