### PR TITLE
Log feedback approvals and add admin viewer

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -1,0 +1,8 @@
+<?php
+$file = __DIR__ . '/validated_responses.json';
+header('Content-Type: application/json; charset=utf-8');
+if (file_exists($file)) {
+    readfile($file);
+} else {
+    echo json_encode([]);
+}

--- a/symplissime-ai.php
+++ b/symplissime-ai.php
@@ -13,6 +13,35 @@ function nocache_url($url) {
     return $url . $separator . 'v=' . time();
 }
 
+// Handle feedback saving
+if (isset($_POST['action']) && $_POST['action'] === 'feedback') {
+    header('Content-Type: application/json');
+    header('Access-Control-Allow-Origin: *');
+
+    $question = $_POST['question'] ?? '';
+    $answer = $_POST['answer'] ?? '';
+    $entry = [
+        'question' => $question,
+        'answer' => $answer,
+        'date' => date('Y-m-d H:i:s')
+    ];
+
+    $file = __DIR__ . '/validated_responses.json';
+    if (!file_exists($file)) {
+        file_put_contents($file, json_encode([]));
+    }
+
+    $data = json_decode(file_get_contents($file), true);
+    if (!is_array($data)) {
+        $data = [];
+    }
+    $data[] = $entry;
+    file_put_contents($file, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+    echo json_encode(['success' => true]);
+    exit;
+}
+
 // Handle chat requests
 if (isset($_POST['action']) && $_POST['action'] === 'chat') {
     header('Content-Type: application/json');

--- a/symplissimeai.js
+++ b/symplissimeai.js
@@ -904,6 +904,15 @@ class SymplissimeAIApp {
         up.onclick = () => {
             this.showToast('Merci pour votre retour!');
             this.launchConfetti();
+            const question = this.messageHistory.slice().reverse().find(m => m.isUser)?.content || '';
+            const formData = new FormData();
+            formData.append('action', 'feedback');
+            formData.append('question', question);
+            formData.append('answer', content);
+            fetch(this.config.API_ENDPOINT, {
+                method: 'POST',
+                body: formData
+            });
             setTimeout(() => {
                 this.addMessage(
                     "Nous serions ravis d'avoir votre avis sur [Trustpilot](https://fr.trustpilot.com/review/symplissime.fr)",


### PR DESCRIPTION
## Summary
- Store thumbs-up feedback with question, answer, and timestamp in `validated_responses.json`
- Send feedback from client when user approves an answer
- Add `admin.php` to display validated responses

## Testing
- `php -l symplissime-ai.php`
- `php -l admin.php`
- `node --check symplissimeai.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab14ba6d04832cbb53cdc15d034a11