### PR TITLE
Remove send button spinner and disable JS caching

### DIFF
--- a/symplissime-ai.php
+++ b/symplissime-ai.php
@@ -1,5 +1,8 @@
 <?php
 session_start();
+header('Cache-Control: no-cache, no-store, must-revalidate');
+header('Pragma: no-cache');
+header('Expires: 0');
 
 // Configuration Symplissime AI
 $BASE_URL = 'http://storage.symplissime.fr:3002';

--- a/symplissimeai.css
+++ b/symplissimeai.css
@@ -1367,31 +1367,6 @@ body {
   }
 }
 
-/* LOADING STATE */
-.loading {
-  position: relative;
-}
-
-.loading::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  width: 16px;
-  height: 16px;
-  margin: auto;
-  border: 2px solid var(--fluent-primary);
-  border-radius: 50%;
-  animation: none;
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
-
 /* === CORRECTIONS DE FORMATAGE === */
 
 /* Formatage optimisé des paragraphes */

--- a/symplissimeai.js
+++ b/symplissimeai.js
@@ -839,11 +839,6 @@ class SymplissimeAIApp {
         
         if (sendButton) {
             sendButton.disabled = processing;
-            if (processing) {
-                sendButton.classList.add('loading');
-            } else {
-                sendButton.classList.remove('loading');
-            }
         }
         
         if (processing) {


### PR DESCRIPTION
## Summary
- remove the rotating indicator when sending messages
- prevent caching of JavaScript assets

## Testing
- `php -l symplissime-ai.php`
- `node --check symplissimeai.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab19383870832ca4fdcd9d2599fde4