### PR TITLE
feat: stream DOM fragments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "codex",
+  "version": "1.0.0",
+  "description": "Ce projet fournit une interface JavaScript pour discuter avec Symplissime AI et téléverser des documents.",
+  "main": "symplissimeai.js",
+  "scripts": {
+    "test": "node test_streaming.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/symplissimeai.js
+++ b/symplissimeai.js
@@ -553,20 +553,23 @@ class SymplissimeAIApp {
         // Convertir le contenu en HTML sécurisé et nettoyé avant le streaming
         const html = this.generateHTML(content);
 
-        // Variables pour le streaming par blocs
-        const totalChars = html.length;
+        // Parse le HTML en nœuds DOM complets pour éviter les balises non fermées
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        const tokens = Array.from(doc.body.childNodes);
+        const totalTokens = tokens.length;
         let currentIndex = 0;
-        const chunkSize = 15; // nombre de caractères affichés à chaque tick
 
-        const streamNextChunk = () => {
-            if (currentIndex < totalChars) {
-                currentIndex = Math.min(currentIndex + chunkSize, totalChars);
-                messageContentDiv.innerHTML = html.slice(0, currentIndex);
+        const streamNextToken = () => {
+            if (currentIndex < totalTokens) {
+                const fragment = document.createDocumentFragment();
+                fragment.appendChild(tokens[currentIndex].cloneNode(true));
+                messageContentDiv.appendChild(fragment);
                 this.scrollToBottom();
-                const progress = Math.round((currentIndex / totalChars) * 100);
+                const progress = Math.round(((currentIndex + 1) / totalTokens) * 100);
                 this.updateStatus('processing', 'Réponse en cours', progress);
-                // Affichage quasi instantané
-                this.streamingInterval = setTimeout(streamNextChunk, 0);
+                this.streamingInterval = setTimeout(streamNextToken, 0);
+                currentIndex++;
             } else {
                 // Streaming terminé
                 this.finishStreaming(messageElement, content);
@@ -574,7 +577,7 @@ class SymplissimeAIApp {
         };
 
         // Démarrer le streaming
-        streamNextChunk();
+        streamNextToken();
     }
 
     createMessageElement(content, isUser = false, isError = false) {

--- a/test_streaming.js
+++ b/test_streaming.js
@@ -1,0 +1,27 @@
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+const htmlTemplate = '<!doctype html><html><body><div id="chatMessages"></div></body></html>';
+const dom = new JSDOM(htmlTemplate, { runScripts: 'dangerously' });
+const { window } = dom;
+window.SYMPLISSIME_CONFIG = {};
+window.marked = { setOptions() {}, parse: (s) => s };
+window.DOMPurify = { sanitize: (s) => s };
+window.hljs = { highlightElement() {} };
+const script = fs.readFileSync('./symplissimeai.js', 'utf8');
+window.eval(script);
+const app = new window.SymplissimeAIApp();
+const content = '<p>Hello <strong>world</strong></p>';
+app.streamMessage(content);
+setTimeout(() => {
+  const rendered = window.document.querySelector('#chatMessages .message').innerHTML.trim();
+  const expected = app.generateHTML(content).trim();
+  if (rendered === expected) {
+    console.log('Streaming output matches expected HTML.');
+    process.exit(0);
+  } else {
+    console.error('Streaming output mismatch.');
+    console.error('Rendered:', rendered);
+    console.error('Expected:', expected);
+    process.exit(1);
+  }
+}, 50);


### PR DESCRIPTION
## Summary
- replace string slicing with DOMParser-based streaming for valid HTML fragments
- scaffold streaming test using jsdom

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_68ab265141b0832c8b8776e57116b44d