### PR TITLE
Improve heading styles and spacing normalization

### DIFF
--- a/symplissimeai.css
+++ b/symplissimeai.css
@@ -1398,7 +1398,7 @@ body {
 
 .message ul.formatted-list,
 .message ol.formatted-list {
-    margin: 0.8em 0;
+    margin: 0 0 0.8em 0;
     padding-left: 1.5em;
     line-height: 1.6;
 }
@@ -1428,6 +1428,11 @@ body {
     margin-bottom: 0;
 }
 
+.message ul.formatted-list:last-child,
+.message ol.formatted-list:last-child {
+    margin-bottom: 0;
+}
+
 .message p.formatted-paragraph:hover,
 .message ul.formatted-list li:hover,
 .message ol.formatted-list li:hover {
@@ -1446,64 +1451,49 @@ body {
     margin-bottom: 0;
 }
 
+/* Suppression des sauts de ligne multiples */
+.message br + br {
+    display: none;
+}
+
 /* Formatage des titres */
-.message h1, .message h2, .message h3,
-.message h4, .message h5, .message h6 {
+.formatted-title {
     margin-top: 1em;
     margin-bottom: 0.5em;
     line-height: 1.3;
     font-weight: 600;
     font-variation-settings: "wght" 600;
     text-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
-    transition: font-variation-settings 0.3s ease, letter-spacing 0.3s ease, text-shadow 0.3s ease;
-}
-
-.message h1,
-.message h2,
-.message h3,
-.message h4,
-.message h5,
-.message h6 {
     background: linear-gradient(90deg, var(--c-pri), var(--c-pri-light));
     background-clip: text;
     -webkit-background-clip: text;
     color: transparent;
     -webkit-text-fill-color: transparent;
-    font-variation-settings: "wght" 600;
-    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
     transition: font-variation-settings 0.3s ease, letter-spacing 0.3s ease, text-shadow 0.3s ease;
 }
 
-.message h1:hover,
-.message h2:hover,
-.message h3:hover {
-    font-weight: 700;
-    font-variation-settings: "wght" 700;
-    letter-spacing: 1px;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-}
-
-.message h4:hover,
-.message h5:hover,
-.message h6:hover {
+.formatted-title:hover {
     font-weight: 700;
     font-variation-settings: "wght" 700;
     letter-spacing: 0.5px;
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
-.message h1:first-child,
-.message h2:first-child,
-.message h3:first-child {
-    margin-top: 0;
+.formatted-title.title-level-1,
+.formatted-title.title-level-2,
+.formatted-title.title-level-3 {
+    letter-spacing: 1px;
 }
 
-/* Espacement entre différents types d'éléments */
-.message p + ul,
-.message p + ol,
-.message ul + p,
-.message ol + p {
-    margin-top: 0.8em;
+.formatted-title.title-level-1 { font-size: 2em; }
+.formatted-title.title-level-2 { font-size: 1.75em; }
+.formatted-title.title-level-3 { font-size: 1.5em; }
+.formatted-title.title-level-4 { font-size: 1.25em; }
+.formatted-title.title-level-5 { font-size: 1.1em; }
+.formatted-title.title-level-6 { font-size: 1em; }
+
+.formatted-title:first-child {
+    margin-top: 0;
 }
 
 /* Formatage des blocs de code */

--- a/symplissimeai.js
+++ b/symplissimeai.js
@@ -689,11 +689,14 @@ class SymplissimeAIApp {
         // Normaliser les fins de ligne
         cleaned = cleaned.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 
+        // Convertir les sauts de ligne HTML en nouvelles lignes pour unifier le traitement
+        cleaned = cleaned.replace(/<br\s*\/?>(\s*)/gi, '\n');
+
         // Supprimer les espaces en début et fin
         cleaned = cleaned.trim();
 
         // Réduire les multiples retours à la ligne consécutifs à maximum 2
-        cleaned = cleaned.replace(/\n{3,}/g, '\n\n');
+        cleaned = cleaned.replace(/(\n\s*){3,}/g, '\n\n');
 
         // Nettoyer les espaces multiples sur une même ligne
         cleaned = cleaned.replace(/[^\S\n]{2,}/g, ' ');
@@ -753,6 +756,14 @@ class SymplissimeAIApp {
         return content;
     }
 
+    markImportantHeadings(root) {
+        if (!root) return;
+        root.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach(h => {
+            const level = parseInt(h.tagName.replace('H', ''), 10);
+            h.classList.add('formatted-title', `title-level-${level}`);
+        });
+    }
+
     postProcessHTML(html) {
         if (!html) return '';
 
@@ -769,7 +780,7 @@ class SymplissimeAIApp {
         });
 
         // Nettoyer les doubles <br>
-        temp.innerHTML = temp.innerHTML.replace(/(<br\s*\/?>){2,}/gi, '<br>');
+        temp.innerHTML = temp.innerHTML.replace(/(<br\s*\/?>\s*){2,}/gi, '<br>');
 
         // Améliorer les listes
         temp.querySelectorAll('ul, ol').forEach(list => {
@@ -781,6 +792,9 @@ class SymplissimeAIApp {
             });
         });
 
+        // Identifier et marquer les titres importants
+        this.markImportantHeadings(temp);
+
         // Améliorer les blocs de code
         temp.querySelectorAll('pre').forEach(pre => {
             pre.classList.add('formatted-code');
@@ -789,12 +803,7 @@ class SymplissimeAIApp {
             }
         });
 
-        let finalHTML = temp.innerHTML;
-        finalHTML = finalHTML.replace(/>\s+</g, '><');
-        finalHTML = finalHTML.replace(/<\/(p|div|blockquote|h[1-6])>/gi, '</$1>\n');
-        finalHTML = finalHTML.replace(/<(p|div|blockquote|h[1-6])/gi, '\n<$1');
-        finalHTML = finalHTML.replace(/\n{3,}/g, '\n\n');
-
+        const finalHTML = temp.innerHTML.replace(/\n{3,}/g, '\n\n');
         return finalHTML.trim();
     }
 


### PR DESCRIPTION
## Summary
- detect and tag headings before rendering so they can receive gradient styling
- normalize line breaks and spacing to avoid extra gaps
- add CSS classes for title levels and unify paragraph/list margins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab2f303ce4832c972427b3c9111e51