### PR TITLE
fix: enforce gradient styling for all headings

### DIFF
--- a/symplissimeai.css
+++ b/symplissimeai.css
@@ -601,7 +601,12 @@ body {
   text-shadow: 0 1px 2px rgba(0,0,0,0.1);
 }
 
-.gradient-title {
+h1.gradient-title,
+h2.gradient-title,
+h3.gradient-title,
+h4.gradient-title,
+h5.gradient-title,
+h6.gradient-title {
   display: inline-block;
   background: linear-gradient(90deg, var(--c-pri-light), var(--c-pri));
   background-clip: text;

--- a/symplissimeai.js
+++ b/symplissimeai.js
@@ -882,22 +882,30 @@ class SymplissimeAIApp {
         return content;
     }
 
-    markImportantHeadings(root) {
+    applyGradientToHeadings(root) {
         if (!root) return;
-        root.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach(h => {
+        const headings = root.querySelectorAll('h1, h2, h3, h4, h5, h6');
+        headings.forEach(h => {
             const level = parseInt(h.tagName.replace('H', ''), 10);
-            h.classList.add('formatted-title', `title-level-${level}`);
+            h.classList.add('gradient-title', 'formatted-title', `title-level-${level}`);
         });
+
+        // Vérification post-traitement : tous les titres doivent avoir la classe gradient-title
+        const missing = Array.from(headings).filter(h => !h.classList.contains('gradient-title'));
+        if (missing.length) {
+            console.warn('Titres sans classe gradient détectés, correction appliquée.');
+            missing.forEach(h => {
+                const level = parseInt(h.tagName.replace('H', ''), 10);
+                h.classList.add('gradient-title', 'formatted-title', `title-level-${level}`);
+            });
+        }
     }
 
     validateFormatting(root) {
         // Vérifie et applique les classes CSS obligatoires
         if (!root) return;
 
-        root.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach(h => {
-            const level = parseInt(h.tagName.replace('H', ''), 10);
-            h.classList.add('formatted-title', `title-level-${level}`);
-        });
+        this.applyGradientToHeadings(root);
 
         root.querySelectorAll('p').forEach(p => {
             if (!p.textContent.trim() && !p.querySelector('img')) {
@@ -956,8 +964,8 @@ class SymplissimeAIApp {
             }
         });
 
-        // Identifier et marquer les titres importants
-        this.markImportantHeadings(temp);
+        // Appliquer systématiquement les classes de titres
+        this.applyGradientToHeadings(temp);
 
         // Améliorer les blocs de code
         temp.querySelectorAll('pre').forEach(pre => {


### PR DESCRIPTION
## Summary
- add function to apply and verify gradient-title classes on all heading levels
- reuse the function at each HTML post-processing stage for consistent formatting
- tighten CSS selector so gradient styling applies uniformly to H1-H6

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab3e8f07a0832c888b8f2cd558d745